### PR TITLE
Fix version used in tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,9 +19,9 @@ autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.0.0"
 junit = "junit:junit:4.13.2"
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
-lint = { module = "com.android.tools.lint:lint", version.ref = "lint" }
-lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
-lint-testUtils = { module = "com.android.tools:testutils", version.ref = "lint" }
+lint = { module = "com.android.tools.lint:lint", version.ref = "lint-latest" }
+lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint-latest" }
+lint-testUtils = { module = "com.android.tools:testutils", version.ref = "lint-latest" }
 
 [bundles]
 lintTest = ["lint", "lint-tests", "lint-testUtils"]


### PR DESCRIPTION
Accidentally pushed to main while resolving #3, this fixes tests to run against the latest lint APIs.


https://github.com/slackhq/compose-lints/actions/runs/4047949611/jobs/6962587920

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->