### PR TITLE
Remove "Compose" prefix from detector names

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposableFunctionNamingDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposableFunctionNamingDetector.kt
@@ -15,7 +15,7 @@ import slack.lint.compose.util.hasReceiverType
 import slack.lint.compose.util.returnsValue
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeNamingDetector
+class ComposableFunctionNamingDetector
 @JvmOverloads
 constructor(
   private val allowedNames: StringSetLintOption =
@@ -44,7 +44,7 @@ constructor(
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
-          implementation = sourceImplementation<ComposeNamingDetector>()
+          implementation = sourceImplementation<ComposableFunctionNamingDetector>()
         )
         .setOptions(listOf(ALLOWED_COMPOSABLE_FUNCTION_NAMES))
 
@@ -61,7 +61,7 @@ constructor(
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
-          implementation = sourceImplementation<ComposeNamingDetector>()
+          implementation = sourceImplementation<ComposableFunctionNamingDetector>()
         )
         .setOptions(listOf(ALLOWED_COMPOSABLE_FUNCTION_NAMES))
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
@@ -24,18 +24,18 @@ class ComposeLintsIssueRegistry : IssueRegistry() {
   @Suppress("SpreadOperator")
   override val issues: List<Issue> =
     listOf(
-      *ComposeNamingDetector.ISSUES,
-      ComposeCompositionLocalUsageDetector.ISSUE,
-      ComposeContentEmitterReturningValuesDetector.ISSUE,
-      ComposeModifierMissingDetector.ISSUE,
-      ComposeModifierReusedDetector.ISSUE,
-      ComposeModifierWithoutDefaultDetector.ISSUE,
-      ComposeMultipleContentEmittersDetector.ISSUE,
-      ComposeMutableParametersDetector.ISSUE,
-      ComposeParameterOrderDetector.ISSUE,
-      ComposePreviewNamingDetector.ISSUE,
-      ComposePreviewPublicDetector.ISSUE,
-      ComposeRememberMissingDetector.ISSUE,
-      ComposeUnstableCollectionsDetector.ISSUE,
+      *ComposableFunctionNamingDetector.ISSUES,
+      CompositionLocalUsageDetector.ISSUE,
+      ContentEmitterReturningValuesDetector.ISSUE,
+      ModifierMissingDetector.ISSUE,
+      ModifierReusedDetector.ISSUE,
+      ModifierWithoutDefaultDetector.ISSUE,
+      MultipleContentEmittersDetector.ISSUE,
+      MutableParametersDetector.ISSUE,
+      ParameterOrderDetector.ISSUE,
+      PreviewNamingDetector.ISSUE,
+      PreviewPublicDetector.ISSUE,
+      RememberMissingDetector.ISSUE,
+      UnstableCollectionsDetector.ISSUE,
     )
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/CompositionLocalUsageDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/CompositionLocalUsageDetector.kt
@@ -19,7 +19,7 @@ import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.declaresCompositionLocal
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeCompositionLocalUsageDetector : Detector(), SourceCodeScanner {
+class CompositionLocalUsageDetector : Detector(), SourceCodeScanner {
 
   companion object {
 
@@ -43,7 +43,7 @@ class ComposeCompositionLocalUsageDetector : Detector(), SourceCodeScanner {
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
-          implementation = sourceImplementation<ComposeCompositionLocalUsageDetector>()
+          implementation = sourceImplementation<CompositionLocalUsageDetector>()
         )
         .setOptions(listOf(ALLOW_LIST))
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ContentEmitterReturningValuesDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ContentEmitterReturningValuesDetector.kt
@@ -22,7 +22,7 @@ import slack.lint.compose.util.hasReceiverType
 import slack.lint.compose.util.isComposable
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeContentEmitterReturningValuesDetector
+class ContentEmitterReturningValuesDetector
 @JvmOverloads
 constructor(
   private val contentEmitterOption: ContentEmitterLintOption =
@@ -46,7 +46,7 @@ constructor(
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
-          implementation = sourceImplementation<ComposeContentEmitterReturningValuesDetector>()
+          implementation = sourceImplementation<ContentEmitterReturningValuesDetector>()
         )
         .setOptions(listOf(CONTENT_EMITTER_OPTION))
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ModifierMissingDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ModifierMissingDetector.kt
@@ -19,7 +19,7 @@ import slack.lint.compose.util.modifierParameter
 import slack.lint.compose.util.returnsValue
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeModifierMissingDetector
+class ModifierMissingDetector
 @JvmOverloads
 constructor(
   private val contentEmitterOption: ContentEmitterLintOption =
@@ -42,7 +42,7 @@ constructor(
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
-          implementation = sourceImplementation<ComposeModifierMissingDetector>()
+          implementation = sourceImplementation<ModifierMissingDetector>()
         )
         .setOptions(listOf(CONTENT_EMITTER_OPTION))
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ModifierReusedDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ModifierReusedDetector.kt
@@ -24,7 +24,7 @@ import slack.lint.compose.util.findChildrenByClass
 import slack.lint.compose.util.modifierParameter
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeModifierReusedDetector
+class ModifierReusedDetector
 @JvmOverloads
 constructor(
   private val contentEmitterOption: ContentEmitterLintOption =
@@ -48,7 +48,7 @@ constructor(
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
-          implementation = sourceImplementation<ComposeModifierReusedDetector>()
+          implementation = sourceImplementation<ModifierReusedDetector>()
         )
         .setOptions(listOf(CONTENT_EMITTER_OPTION))
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ModifierWithoutDefaultDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ModifierWithoutDefaultDetector.kt
@@ -19,7 +19,7 @@ import slack.lint.compose.util.isOverride
 import slack.lint.compose.util.lastChildLeafOrSelf
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeModifierWithoutDefaultDetector : ComposableFunctionDetector(), SourceCodeScanner {
+class ModifierWithoutDefaultDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
   companion object {
     val ISSUE =
@@ -34,7 +34,7 @@ class ComposeModifierWithoutDefaultDetector : ComposableFunctionDetector(), Sour
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,
-        implementation = sourceImplementation<ComposeModifierWithoutDefaultDetector>()
+        implementation = sourceImplementation<ModifierWithoutDefaultDetector>()
       )
   }
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
@@ -22,7 +22,7 @@ import slack.lint.compose.util.hasReceiverType
 import slack.lint.compose.util.isComposable
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeMultipleContentEmittersDetector
+class MultipleContentEmittersDetector
 @JvmOverloads
 constructor(
   private val contentEmitterOption: ContentEmitterLintOption =
@@ -45,7 +45,7 @@ constructor(
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
-          implementation = sourceImplementation<ComposeMultipleContentEmittersDetector>()
+          implementation = sourceImplementation<MultipleContentEmittersDetector>()
         )
         .setOptions(listOf(CONTENT_EMITTER_OPTION))
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
@@ -13,7 +13,7 @@ import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isTypeMutable
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeMutableParametersDetector : ComposableFunctionDetector(), SourceCodeScanner {
+class MutableParametersDetector : ComposableFunctionDetector(), SourceCodeScanner {
   companion object {
     val ISSUE =
       Issue.create(
@@ -28,7 +28,7 @@ class ComposeMutableParametersDetector : ComposableFunctionDetector(), SourceCod
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,
-        implementation = sourceImplementation<ComposeMutableParametersDetector>()
+        implementation = sourceImplementation<MutableParametersDetector>()
       )
   }
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -15,7 +15,7 @@ import slack.lint.compose.util.isModifier
 import slack.lint.compose.util.runIf
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
+class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
   companion object {
     fun createErrorMessage(
@@ -43,7 +43,7 @@ class ComposeParameterOrderDetector : ComposableFunctionDetector(), SourceCodeSc
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,
-        implementation = sourceImplementation<ComposeParameterOrderDetector>()
+        implementation = sourceImplementation<ParameterOrderDetector>()
       )
   }
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/PreviewNamingDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/PreviewNamingDetector.kt
@@ -17,7 +17,7 @@ import slack.lint.compose.util.isPreview
 import slack.lint.compose.util.isPreviewAnnotation
 import slack.lint.compose.util.sourceImplementation
 
-class ComposePreviewNamingDetector : Detector(), SourceCodeScanner {
+class PreviewNamingDetector : Detector(), SourceCodeScanner {
 
   companion object {
     fun createMessage(count: Int, suggestedSuffix: String): String =
@@ -35,7 +35,7 @@ class ComposePreviewNamingDetector : Detector(), SourceCodeScanner {
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,
-        implementation = sourceImplementation<ComposePreviewNamingDetector>()
+        implementation = sourceImplementation<PreviewNamingDetector>()
       )
   }
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/PreviewPublicDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/PreviewPublicDetector.kt
@@ -21,7 +21,7 @@ import slack.lint.compose.util.isPreview
 import slack.lint.compose.util.isPreviewParameter
 import slack.lint.compose.util.sourceImplementation
 
-class ComposePreviewPublicDetector
+class PreviewPublicDetector
 @JvmOverloads
 constructor(
   private val previewPublicOnlyIfParams: BooleanLintOption =
@@ -49,7 +49,7 @@ constructor(
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
-          implementation = sourceImplementation<ComposePreviewPublicDetector>()
+          implementation = sourceImplementation<PreviewPublicDetector>()
         )
         .setOptions(listOf(PREVIEW_PUBLIC_ONLY_IF_PARAMS_OPTION))
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/RememberMissingDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/RememberMissingDetector.kt
@@ -14,7 +14,7 @@ import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.findChildrenByClass
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeRememberMissingDetector : ComposableFunctionDetector(), SourceCodeScanner {
+class RememberMissingDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
   companion object {
     private fun errorMessage(name: String): String =
@@ -37,7 +37,7 @@ class ComposeRememberMissingDetector : ComposableFunctionDetector(), SourceCodeS
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,
-        implementation = sourceImplementation<ComposeRememberMissingDetector>()
+        implementation = sourceImplementation<RememberMissingDetector>()
       )
   }
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableCollectionsDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableCollectionsDetector.kt
@@ -13,7 +13,7 @@ import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isTypeUnstableCollection
 import slack.lint.compose.util.sourceImplementation
 
-class ComposeUnstableCollectionsDetector : ComposableFunctionDetector(), SourceCodeScanner {
+class UnstableCollectionsDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
   companion object {
     private val DiamondRegex by lazy(LazyThreadSafetyMode.NONE) { Regex("<.*>\\??") }
@@ -38,7 +38,7 @@ class ComposeUnstableCollectionsDetector : ComposableFunctionDetector(), SourceC
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,
         severity = Severity.WARNING,
-        implementation = sourceImplementation<ComposeUnstableCollectionsDetector>()
+        implementation = sourceImplementation<UnstableCollectionsDetector>()
       )
   }
 

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ComposableFunctionNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ComposableFunctionNamingDetectorTest.kt
@@ -9,17 +9,20 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeNamingDetectorTest : BaseSlackLintTest() {
+class ComposableFunctionNamingDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeNamingDetector()
-  override fun getIssues(): List<Issue> = ComposeNamingDetector.ISSUES.toList()
+  override fun getDetector(): Detector = ComposableFunctionNamingDetector()
+  override fun getIssues(): List<Issue> = ComposableFunctionNamingDetector.ISSUES.toList()
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)
 
   override fun lint(): TestLintTask {
     return super.lint()
-      .configureOption(ComposeNamingDetector.ALLOWED_COMPOSABLE_FUNCTION_NAMES, ".*Presenter")
+      .configureOption(
+        ComposableFunctionNamingDetector.ALLOWED_COMPOSABLE_FUNCTION_NAMES,
+        ".*Presenter"
+      )
   }
 
   @Test

--- a/compose-lint-checks/src/test/java/slack/lint/compose/CompositionLocalUsageDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/CompositionLocalUsageDetectorTest.kt
@@ -8,14 +8,14 @@ import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import org.junit.Test
 
-class ComposeCompositionLocalUsageDetectorTest : BaseSlackLintTest() {
+class CompositionLocalUsageDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeCompositionLocalUsageDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeCompositionLocalUsageDetector.ISSUE)
+  override fun getDetector(): Detector = CompositionLocalUsageDetector()
+  override fun getIssues(): List<Issue> = listOf(CompositionLocalUsageDetector.ISSUE)
 
   override fun lint(): TestLintTask {
     return super.lint()
-      .configureOption(ComposeCompositionLocalUsageDetector.ALLOW_LIST, "LocalBanana,LocalPotato")
+      .configureOption(CompositionLocalUsageDetector.ALLOW_LIST, "LocalBanana,LocalPotato")
   }
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ContentEmitterReturningValuesDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ContentEmitterReturningValuesDetectorTest.kt
@@ -9,15 +9,15 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
+class ContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeMultipleContentEmittersDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeMultipleContentEmittersDetector.ISSUE)
+  override fun getDetector(): Detector = ContentEmitterReturningValuesDetector()
+  override fun getIssues(): List<Issue> = listOf(ContentEmitterReturningValuesDetector.ISSUE)
 
   override fun lint(): TestLintTask {
     return super.lint()
       .configureOption(
-        ComposeMultipleContentEmittersDetector.CONTENT_EMITTER_OPTION,
+        ContentEmitterReturningValuesDetector.CONTENT_EMITTER_OPTION,
         "Potato,Banana"
       )
   }
@@ -89,12 +89,14 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
-          src/test.kt:6: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:6: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
           2 errors, 0 warnings
@@ -138,12 +140,14 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:5: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:5: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
-          src/test.kt:18: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:18: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
           2 errors, 0 warnings
@@ -175,8 +179,9 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
           1 errors, 0 warnings

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierMissingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierMissingDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeModifierMissingDetectorTest : BaseSlackLintTest() {
+class ModifierMissingDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeModifierMissingDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeModifierMissingDetector.ISSUE)
+  override fun getDetector(): Detector = ModifierMissingDetector()
+  override fun getIssues(): List<Issue> = listOf(ModifierMissingDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierReusedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierReusedDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeModifierReusedDetectorTest : BaseSlackLintTest() {
+class ModifierReusedDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeModifierReusedDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeModifierReusedDetector.ISSUE)
+  override fun getDetector(): Detector = ModifierReusedDetector()
+  override fun getIssues(): List<Issue> = listOf(ModifierReusedDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierWithoutDefaultDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierWithoutDefaultDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeModifierWithoutDefaultDetectorTest : BaseSlackLintTest() {
+class ModifierWithoutDefaultDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeModifierWithoutDefaultDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeModifierWithoutDefaultDetector.ISSUE)
+  override fun getDetector(): Detector = ModifierWithoutDefaultDetector()
+  override fun getIssues(): List<Issue> = listOf(ModifierWithoutDefaultDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
@@ -9,17 +9,14 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
+class MultipleContentEmittersDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeContentEmitterReturningValuesDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeContentEmitterReturningValuesDetector.ISSUE)
+  override fun getDetector(): Detector = MultipleContentEmittersDetector()
+  override fun getIssues(): List<Issue> = listOf(MultipleContentEmittersDetector.ISSUE)
 
   override fun lint(): TestLintTask {
     return super.lint()
-      .configureOption(
-        ComposeContentEmitterReturningValuesDetector.CONTENT_EMITTER_OPTION,
-        "Potato,Banana"
-      )
+      .configureOption(MultipleContentEmittersDetector.CONTENT_EMITTER_OPTION, "Potato,Banana")
   }
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
@@ -89,14 +86,12 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.
-          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
-          src/test.kt:6: Error: Composable functions should either emit content into the composition or return a value, but not both.
-          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:6: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           2 errors, 0 warnings
@@ -140,14 +135,12 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:5: Error: Composable functions should either emit content into the composition or return a value, but not both.
-          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:5: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
-          src/test.kt:18: Error: Composable functions should either emit content into the composition or return a value, but not both.
-          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:18: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           2 errors, 0 warnings
@@ -179,9 +172,8 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.
-          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           1 errors, 0 warnings

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeMutableParametersDetectorTest : BaseSlackLintTest() {
+class MutableParametersDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeMutableParametersDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeMutableParametersDetector.ISSUE)
+  override fun getDetector(): Detector = MutableParametersDetector()
+  override fun getIssues(): List<Issue> = listOf(MutableParametersDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeParameterOrderDetectorTest : BaseSlackLintTest() {
+class ParameterOrderDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeParameterOrderDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeParameterOrderDetector.ISSUE)
+  override fun getDetector(): Detector = ParameterOrderDetector()
+  override fun getIssues(): List<Issue> = listOf(ParameterOrderDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)

--- a/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposePreviewNamingDetectorTest : BaseSlackLintTest() {
+class PreviewNamingDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposePreviewNamingDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposePreviewNamingDetector.ISSUE)
+  override fun getDetector(): Detector = PreviewNamingDetector()
+  override fun getIssues(): List<Issue> = listOf(PreviewNamingDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)

--- a/compose-lint-checks/src/test/java/slack/lint/compose/PreviewPublicDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/PreviewPublicDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposePreviewPublicDetectorTest : BaseSlackLintTest() {
+class PreviewPublicDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposePreviewPublicDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposePreviewPublicDetector.ISSUE)
+  override fun getDetector(): Detector = PreviewPublicDetector()
+  override fun getIssues(): List<Issue> = listOf(PreviewPublicDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)
@@ -58,7 +58,7 @@ class ComposePreviewPublicDetectorTest : BaseSlackLintTest() {
       """
         .trimIndent()
     lint()
-      .configureOption(ComposePreviewPublicDetector.PREVIEW_PUBLIC_ONLY_IF_PARAMS_OPTION, "false")
+      .configureOption(PreviewPublicDetector.PREVIEW_PUBLIC_ONLY_IF_PARAMS_OPTION, "false")
       .files(kotlin(code))
       .allowCompilationErrors()
       .run()

--- a/compose-lint-checks/src/test/java/slack/lint/compose/RememberMissingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/RememberMissingDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeRememberMissingDetectorTest : BaseSlackLintTest() {
+class RememberMissingDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeRememberMissingDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeRememberMissingDetector.ISSUE)
+  override fun getDetector(): Detector = RememberMissingDetector()
+  override fun getIssues(): List<Issue> = listOf(RememberMissingDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableCollectionsDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableCollectionsDetectorTest.kt
@@ -8,10 +8,10 @@ import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
-class ComposeUnstableCollectionsDetectorTest : BaseSlackLintTest() {
+class UnstableCollectionsDetectorTest : BaseSlackLintTest() {
 
-  override fun getDetector(): Detector = ComposeUnstableCollectionsDetector()
-  override fun getIssues(): List<Issue> = listOf(ComposeUnstableCollectionsDetector.ISSUE)
+  override fun getDetector(): Detector = UnstableCollectionsDetector()
+  override fun getIssues(): List<Issue> = listOf(UnstableCollectionsDetector.ISSUE)
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> =


### PR DESCRIPTION
This is a bit redundant in the class/file names here, but kept in issue IDs.

Renamed `ComposeNamingDetector` to `ComposableFunctionNamingDetector` since `NamingDetector` felt vague.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->