### PR TITLE
Automate website publishing

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,56 @@
+name: Publish docs
+
+on:
+  # Run on new version tags...
+  push:
+    tags:
+      - v*
+  # or manually from workflow dispatch (from GitHub UI)
+  workflow_dispatch:
+
+jobs:
+  deploy_docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '19'
+
+      - name: Build Dokka API docs
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: dokkaHtml --no-configuration-cache
+
+      - name: Copy docs files
+        run: |
+          # Copy in special files that GitHub wants in the project root
+          cp CHANGELOG.md docs/changelog.md
+          cp .github/CONTRIBUTING.md docs/contributing.md
+          cp .github/CODE_OF_CONDUCT.md docs/code-of-conduct.md
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r .github/workflows/mkdocs-requirements.txt
+
+      - name: Build site
+        run: mkdocs build -d site
+
+      - name: Deploy site
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ subprojects {
     apply(plugin = "org.jetbrains.dokka")
 
     tasks.withType<DokkaTask>().configureEach {
-      outputDirectory.set(rootDir.resolve("../docs/0.x"))
+      outputDirectory.set(rootDir.resolve("docs/api/0.x"))
       dokkaSourceSets.configureEach { skipDeprecated.set(true) }
     }
 

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -24,7 +24,7 @@ if ! [[ ${local} ]]; then
   cd ${DIR}
 
   # Generate the API docs
-  ./gradlew dokkaGfm --no-configuration-cache
+  ./gradlew dokkaHtml --no-configuration-cache
 
 fi
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,5 +61,6 @@ nav:
   - 'Rules': rules.md
   - 'Discussions ⏏': https://github.com/slackhq/compose-lints/discussions
   - 'Change Log': changelog.md
+  - 'API': api/0.x/
   - 'Contributing': contributing.md
   - 'CoC': code-of-conduct.md


### PR DESCRIPTION
Currently, it runs automatically whenever a new version tag is pushed. There's also workflow_dispatch set, enabling manual invoking from the GitHub Actions UI.

Some changes here:
- Add an 'API' main nav item
- Tweaked Dokka to generate API docs in HTML. The GFM output is mostly useless.
- Fixed Dokka's output folder