### PR TITLE
Port ViewModelForwarding detector

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelForwardingDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelForwardingDetector.kt
@@ -1,0 +1,81 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.*
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import slack.lint.compose.util.*
+import slack.lint.compose.util.sourceImplementation
+
+class ViewModelForwardingDetector : ComposableFunctionDetector(), SourceCodeScanner {
+
+  companion object {
+    val ISSUE =
+      Issue.create(
+        id = "ViewModelForwarding",
+        briefDescription =
+          "Forwarding a ViewModel through multiple @Composable functions should be avoided",
+        explanation =
+          """
+          Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using state hoisting.
+          See https://slackhq.github.io/compose-lints/rules/#hoist-all-the-things for more information.
+        """,
+        category = Category.CORRECTNESS,
+        priority = Priorities.NORMAL,
+        severity = Severity.ERROR,
+        implementation = sourceImplementation<ViewModelForwardingDetector>()
+      )
+  }
+
+  override fun visitComposable(context: JavaContext, function: KtFunction) {
+
+    if (function.isOverride || function.definedInInterface || function.isActual) return
+    val bodyBlock = function.bodyBlockExpression ?: return
+
+    // We get here a list of variable names that tentatively contain ViewModels
+    val parameters = function.valueParameterList?.parameters ?: emptyList()
+    val viewModelParameterNames =
+      parameters
+        .filter { parameter ->
+          // We can't do much better than this. We could look for viewModel() / weaverViewModel()
+          // but that
+          // would give us way less (and less useful) hits.
+          parameter.typeReference?.text?.endsWith("ViewModel") ?: false
+        }
+        .mapNotNull { it.name }
+        .toSet()
+
+    // We want now to see if these parameter names are used in any other calls to functions that
+    // start with
+    // a capital letter (so, most likely, composables).
+    val forwardingCallExpressions =
+      bodyBlock
+        .findDirectChildrenByClass<KtCallExpression>()
+        .filter { callExpression ->
+          callExpression.calleeExpression?.text?.first()?.isUpperCase() ?: false
+        }
+        // Avoid LaunchedEffect/DisposableEffect/etc that can use the VM as a key
+        .filterNot { callExpression -> callExpression.isRestartableEffect }
+        .flatMap { callExpression ->
+          // Get VALUE_ARGUMENT that has a REFERENCE_EXPRESSION. This would map to `viewModel` in
+          // this example:
+          // MyComposable(viewModel, ...)
+          callExpression.valueArguments
+            .mapNotNull { valueArgument ->
+              valueArgument.getArgumentExpression() as? KtReferenceExpression
+            }
+            .filter { reference -> reference.text in viewModelParameterNames }
+            .map { callExpression }
+        }
+    for (callExpression in forwardingCallExpressions) {
+      context.report(
+        ISSUE,
+        callExpression,
+        context.getLocation(callExpression),
+        ISSUE.getExplanation(TextFormat.TEXT)
+      )
+    }
+  }
+}

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelForwardingDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelForwardingDetector.kt
@@ -2,11 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
-import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtReferenceExpression
-import slack.lint.compose.util.*
+import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.definedInInterface
+import slack.lint.compose.util.findDirectChildrenByClass
+import slack.lint.compose.util.isActual
+import slack.lint.compose.util.isOverride
+import slack.lint.compose.util.isRestartableEffect
 import slack.lint.compose.util.sourceImplementation
 
 class ViewModelForwardingDetector : ComposableFunctionDetector(), SourceCodeScanner {

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ViewModelForwardingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ViewModelForwardingDetectorTest.kt
@@ -1,0 +1,109 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class ViewModelForwardingDetectorTest : BaseSlackLintTest() {
+
+  override fun getDetector(): Detector = ViewModelForwardingDetector()
+  override fun getIssues(): List<Issue> = listOf(ViewModelForwardingDetector.ISSUE)
+
+  // This mode is irrelevant to our test and totally untestable with stringy outputs
+  override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)
+
+  @Test
+  fun `allows the forwarding of ViewModels in overridden Composable functions`() {
+    @Language("kotlin")
+    val code =
+      """
+            @Composable
+            override fun Content() {
+                val viewModel = weaverViewModel<MyVM>()
+                AnotherComposable(viewModel)
+            }
+            """
+        .trimIndent()
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+
+  @Test
+  fun `allows the forwarding of ViewModels in interface Composable functions`() {
+    @Language("kotlin")
+    val code =
+      """
+            interface MyInterface {
+                @Composable
+                fun Content() {
+                    val viewModel = weaverViewModel<MyVM>()
+                    AnotherComposable(viewModel)
+                }
+            }
+            """
+        .trimIndent()
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+
+  @Test
+  fun `using state hoisting properly shouldn't be flagged`() {
+    @Language("kotlin")
+    val code =
+      """
+            @Composable
+            fun MyComposable(viewModel: MyViewModel = weaverViewModel()) {
+                val state by viewModel.watchAsState()
+                AnotherComposable(state, onAvatarClicked = { viewModel(AvatarClickedIntent) })
+            }
+            """
+        .trimIndent()
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+
+  @Test
+  fun `errors when a ViewModel is forwarded to another Composable`() {
+    @Language("kotlin")
+    val code =
+      """
+            @Composable
+            fun MyComposable(viewModel: MyViewModel) {
+                AnotherComposable(viewModel)
+            }
+            """
+        .trimIndent()
+    lint()
+      .files(kotlin(code))
+      .allowCompilationErrors()
+      .run()
+      .expect(
+        """
+          src/test.kt:3: Error: Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using state hoisting.
+          See https://slackhq.github.io/compose-lints/rules/#hoist-all-the-things for more information. [ViewModelForwarding]
+              AnotherComposable(viewModel)
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `allows the forwarding of ViewModels that are used as keys`() {
+    @Language("kotlin")
+    val code =
+      """
+            @Composable
+            fun Content() {
+                val viewModel = weaverViewModel<MyVM>()
+                key(viewModel) { }
+                val x = remember(viewModel) { "ABC" }
+                LaunchedEffect(viewModel) { }
+            }
+            """
+        .trimIndent()
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+}


### PR DESCRIPTION
Ports over the code from https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeViewModelForwarding.kt to be usable in lint.

Tracked by #24
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->