### PR TITLE
Finish porting remaining rules

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
@@ -27,6 +27,7 @@ class ComposeLintsIssueRegistry : IssueRegistry() {
       *ComposableFunctionNamingDetector.ISSUES,
       CompositionLocalUsageDetector.ISSUE,
       ContentEmitterReturningValuesDetector.ISSUE,
+      ModifierComposableDetector.ISSUE,
       ModifierMissingDetector.ISSUE,
       ModifierReusedDetector.ISSUE,
       ModifierWithoutDefaultDetector.ISSUE,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
@@ -37,5 +37,7 @@ class ComposeLintsIssueRegistry : IssueRegistry() {
       PreviewPublicDetector.ISSUE,
       RememberMissingDetector.ISSUE,
       UnstableCollectionsDetector.ISSUE,
+      ViewModelForwardingDetector.ISSUE,
+      ViewModelInjectionDetector.ISSUE,
     )
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposableDetector.kt
@@ -1,0 +1,45 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.kotlin.psi.KtFunction
+import slack.lint.compose.util.*
+import slack.lint.compose.util.sourceImplementation
+
+class ModifierComposableDetector : ComposableFunctionDetector(), SourceCodeScanner {
+
+  companion object {
+    val ISSUE =
+      Issue.create(
+        id = "ComposeComposableModifier",
+        briefDescription = "Using @Composable builder functions for modifiers is not recommended",
+        explanation =
+          """
+          Using @Composable builder functions for modifiers is not recommended, as they cause unnecessary recompositions.
+          You should use Modifier.composed { ... } instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
+          See https://slackhq.github.io/compose-lints/rules/#avoid-modifier-extension-factory-functions for more information.
+        """
+            .trimIndent(),
+        category = Category.CORRECTNESS,
+        priority = Priorities.NORMAL,
+        severity = Severity.ERROR,
+        implementation = sourceImplementation<ModifierComposableDetector>()
+      )
+  }
+
+  override fun visitComposable(context: JavaContext, function: KtFunction) {
+    if (!function.isModifierReceiver) return
+    context.report(
+      ISSUE,
+      function,
+      context.getLocation(function),
+      ISSUE.getExplanation(TextFormat.TEXT),
+    )
+  }
+}

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposableDetector.kt
@@ -24,8 +24,7 @@ class ModifierComposableDetector : ComposableFunctionDetector(), SourceCodeScann
           Using @Composable builder functions for modifiers is not recommended, as they cause unnecessary recompositions.
           You should use Modifier.composed { ... } instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
           See https://slackhq.github.io/compose-lints/rules/#avoid-modifier-extension-factory-functions for more information.
-        """
-            .trimIndent(),
+        """,
         category = Category.CORRECTNESS,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelInjectionDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelInjectionDetector.kt
@@ -66,7 +66,7 @@ class ViewModelInjectionDetector : ComposableFunctionDetector(), SourceCodeScann
           context.getLocation(property),
           errorMessage(viewModelFactoryName),
           // TODO would be cool if we could auto-apply a fix like the detekt/ktlint version, but
-          // requires a rewrite.
+          //  requires a rewrite.
         )
       }
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelInjectionDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelInjectionDetector.kt
@@ -1,0 +1,73 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import slack.lint.compose.util.*
+import slack.lint.compose.util.sourceImplementation
+
+class ViewModelInjectionDetector : ComposableFunctionDetector(), SourceCodeScanner {
+
+  companion object {
+    private fun errorMessage(factoryName: String): String =
+      """
+        Implicit dependencies of composables should be made explicit.
+        Usages of $factoryName to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
+        See https://slackhq.github.io/compose-lints/rules/#viewmodels for more information.
+      """
+        .trimIndent()
+
+    val ISSUE =
+      Issue.create(
+        id = "ComposeViewModelInjection",
+        briefDescription = "Implicit dependencies of composables should be made explicit",
+        explanation = "Replaced when reporting",
+        category = Category.CORRECTNESS,
+        priority = Priorities.NORMAL,
+        severity = Severity.ERROR,
+        implementation = sourceImplementation<ViewModelInjectionDetector>()
+      )
+
+    private val KnownViewModelFactories by lazy {
+      setOf(
+        "viewModel", // AAC VM
+        "weaverViewModel", // Weaver
+        "hiltViewModel", // Hilt
+        "injectedViewModel", // Whetstone
+        "mavericksViewModel", // Mavericks
+      )
+    }
+  }
+
+  override fun visitComposable(context: JavaContext, function: KtFunction) {
+    if (function.isOverride || function.definedInInterface) return
+
+    val bodyBlock = function.bodyBlockExpression ?: return
+
+    bodyBlock
+      .findChildrenByClass<KtProperty>()
+      .flatMap { property ->
+        property
+          .findDirectChildrenByClass<KtCallExpression>()
+          .filter { KnownViewModelFactories.contains(it.calleeExpression?.text) }
+          .map { property to it.calleeExpression!!.text }
+      }
+      .forEach { (property, viewModelFactoryName) ->
+        context.report(
+          ISSUE,
+          property,
+          context.getLocation(property),
+          errorMessage(viewModelFactoryName),
+          // TODO would be cool if we could auto-apply a fix like the detekt/ktlint version, but
+          // requires a rewrite.
+        )
+      }
+  }
+}

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierComposableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierComposableDetectorTest.kt
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class ModifierComposableDetectorTest : BaseSlackLintTest() {
+
+  override fun getDetector(): Detector = ModifierComposableDetector()
+  override fun getIssues(): List<Issue> = listOf(ModifierComposableDetector.ISSUE)
+
+  // This mode is irrelevant to our test and totally untestable with stringy outputs
+  override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)
+
+  @Test
+  fun `errors when a composable Modifier extension is detected`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun Modifier.something1(): Modifier { }
+        @Composable
+        fun Modifier.something2() = somethingElse()
+      """
+        .trimIndent()
+
+    lint()
+      .files(kotlin(code))
+      .allowCompilationErrors()
+      .run()
+      .expect(
+        """
+          src/test.kt:1: Error: Using @Composable builder functions for modifiers is not recommended, as they cause unnecessary recompositions.
+          You should use Modifier.composed { ... } instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
+          See https://slackhq.github.io/compose-lints/rules/#avoid-modifier-extension-factory-functions for more information. [ComposeComposableModifier]
+          @Composable
+          ^
+          src/test.kt:3: Error: Using @Composable builder functions for modifiers is not recommended, as they cause unnecessary recompositions.
+          You should use Modifier.composed { ... } instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
+          See https://slackhq.github.io/compose-lints/rules/#avoid-modifier-extension-factory-functions for more information. [ComposeComposableModifier]
+          @Composable
+          ^
+          2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `do not error on a regular composable`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun TextHolder(text: String) {}
+      """
+        .trimIndent()
+
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+}

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ViewModelInjectionDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ViewModelInjectionDetectorTest.kt
@@ -1,0 +1,156 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class ViewModelInjectionDetectorTest(private val viewModel: String) : BaseSlackLintTest() {
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "viewModel = {0}")
+    fun data(): Collection<Array<String>> {
+      return listOf(
+        arrayOf("viewModel"),
+        arrayOf("weaverViewModel"),
+        arrayOf("hiltViewModel"),
+        arrayOf("injectedViewModel"),
+        arrayOf("mavericksViewModel")
+      )
+    }
+  }
+
+  override fun getDetector(): Detector = ViewModelInjectionDetector()
+  override fun getIssues(): List<Issue> = listOf(ViewModelInjectionDetector.ISSUE)
+
+  // This mode is irrelevant to our test and totally untestable with stringy outputs
+  override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)
+
+  @Test
+  fun `passes when a weaverViewModel is used as a default param`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun MyComposable(
+          modifier: Modifier,
+          viewModel: MyVM = $viewModel(),
+          viewModel2: MyVM = $viewModel(),
+        ) { }
+      """
+        .trimIndent()
+
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+
+  @Test
+  fun `overridden functions are ignored`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        override fun Content() {
+          val viewModel = $viewModel<MyVM>()
+        }
+      """
+        .trimIndent()
+
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+
+  @Test
+  fun `errors when a weaverViewModel is used at the beginning of a Composable`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun MyComposable(modifier: Modifier) {
+          val viewModel = $viewModel<MyVM>()
+        }
+
+        @Composable
+        fun MyComposableNoParams() {
+          val viewModel: MyVM = $viewModel()
+        }
+
+        @Composable
+        fun MyComposableTrailingLambda(block: () -> Unit) {
+          val viewModel: MyVM = $viewModel()
+        }
+      """
+        .trimIndent()
+
+    val vmWordUnderline = "~".repeat(viewModel.length)
+    lint()
+      .files(kotlin(code))
+      .allowCompilationErrors()
+      .run()
+      .expect(
+        """
+            src/test.kt:3: Error: Implicit dependencies of composables should be made explicit.
+            Usages of $viewModel to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
+            See https://slackhq.github.io/compose-lints/rules/#viewmodels for more information. [ComposeViewModelInjection]
+              val viewModel = $viewModel<MyVM>()
+              ~~~~~~~~~~~~~~~~$vmWordUnderline~~~~~~~~
+            src/test.kt:8: Error: Implicit dependencies of composables should be made explicit.
+            Usages of $viewModel to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
+            See https://slackhq.github.io/compose-lints/rules/#viewmodels for more information. [ComposeViewModelInjection]
+              val viewModel: MyVM = $viewModel()
+              ~~~~~~~~~~~~~~~~~~~~~~$vmWordUnderline~~
+            src/test.kt:13: Error: Implicit dependencies of composables should be made explicit.
+            Usages of $viewModel to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
+            See https://slackhq.github.io/compose-lints/rules/#viewmodels for more information. [ComposeViewModelInjection]
+              val viewModel: MyVM = $viewModel()
+              ~~~~~~~~~~~~~~~~~~~~~~$vmWordUnderline~~
+            3 errors, 0 warnings
+          """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors when a weaverViewModel is used in different branches`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun MyComposable(modifier: Modifier) {
+          if (blah) {
+            val viewModel = $viewModel<MyVM>()
+          } else {
+            val viewModel: MyOtherVM = $viewModel()
+          }
+        }
+      """
+        .trimIndent()
+
+    val vmWordUnderline = "~".repeat(viewModel.length)
+    lint()
+      .files(kotlin(code))
+      .allowCompilationErrors()
+      .run()
+      .expect(
+        """
+            src/test.kt:4: Error: Implicit dependencies of composables should be made explicit.
+            Usages of $viewModel to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
+            See https://slackhq.github.io/compose-lints/rules/#viewmodels for more information. [ComposeViewModelInjection]
+                val viewModel = $viewModel<MyVM>()
+                ~~~~~~~~~~~~~~~~$vmWordUnderline~~~~~~~~
+            src/test.kt:6: Error: Implicit dependencies of composables should be made explicit.
+            Usages of $viewModel to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
+            See https://slackhq.github.io/compose-lints/rules/#viewmodels for more information. [ComposeViewModelInjection]
+                val viewModel: MyOtherVM = $viewModel()
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~$vmWordUnderline~~
+            2 errors, 0 warnings
+          """
+          .trimIndent()
+      )
+  }
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -176,6 +176,36 @@ Related rule: [`ComposeParameterOrder`](https://github.com/slackhq/compose-lints
 
 ### Make dependencies explicit
 
+#### ViewModels
+
+When designing composables, try to be explicit about the dependencies they take in. If you acquire a `ViewModel` or an instance from DI in the body of the composable, you are making this dependency implicit, which has the downsides of making it hard to test and harder to reuse.
+
+To solve this problem, you should inject these dependencies as default values in the composable function.
+
+Let's see it with an example.
+
+```kotlin
+@Composable
+private fun MyComposable() {
+    val viewModel = viewModel<MyViewModel>()
+    // ...
+}
+```
+In this composable, the dependencies are implicit. When testing it you would need to fake the internals of viewModel somehow to be able to acquire your intended ViewModel.
+
+But, if you change it to pass these instances via the composable function parameters, you could provide the instance you want directly in your tests without any extra effort. It would also have the upside of the function being explicit about its external dependencies in its signature.
+
+```kotlin
+@Composable
+private fun MyComposable(
+    viewModel: MyViewModel = viewModel(),
+) {
+    // ...
+}
+```
+
+Related rule: [`ComposeViewModelInjection`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ViewModelInjectionDetector.kt)
+
 #### `CompositionLocal`s
 
 `CompositionLocal` makes a composable's behavior harder to reason about. As they create implicit dependencies, callers of composables that use them need to make sure that a value for every CompositionLocal is satisfied.
@@ -252,3 +282,13 @@ Composables that accept a Modifier as a parameter to be applied to the whole com
 More info: [Modifier documentation](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier)
 
 Related rule: [`ComposeModifierWithoutDefault`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ModifierWithoutDefaultDetector.kt)
+
+### Avoid Modifier extension factory functions
+
+Using `@Composable` builder functions for modifiers is not recommended, as they cause unnecessary recompositions. To avoid this, you should use `Modifier.composed` instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
+
+Composed modifiers may be created outside of composition, shared across elements, and declared as top-level constants, making them more flexible than modifiers that can only be created via a `@Composable` function call, and easier to avoid accidentally sharing state across elements.
+
+More info: [Modifier extensions](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#extension-functions), [Composed modifiers in Jetpack Compose by Jorge Castillo](https://jorgecastillo.dev/composed-modifiers-in-jetpack-compose) and [Composed modifiers in API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#composed-modifiers)
+
+Related rule: [`ComposeComposableModifier`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposableDetector.kt)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,6 @@ dependencyResolutionManagement {
   }
 }
 
-rootProject.name = "slack-lints"
+rootProject.name = "compose-lints"
 
 include(":compose-lint-checks")


### PR DESCRIPTION
Resolves #24 with the final two rules!

Also adds their docs and opportunistically fixes the ViewModelForwarding detector not being wired up in the registry.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->