### PR TITLE
Misc mutable parameter fixes

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
@@ -36,11 +36,11 @@ class MutableParametersDetector : ComposableFunctionDetector(), SourceCodeScanne
   override fun visitComposable(context: JavaContext, function: KtFunction) {
     function.valueParameters
       .filter { it.isTypeMutable }
-      .forEach {
+      .forEach { parameter ->
         context.report(
           ISSUE,
-          function,
-          context.getNameLocation(function),
+          parameter.typeReference,
+          context.getLocation(parameter.typeReference),
           ISSUE.getExplanation(TextFormat.TEXT)
         )
       }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
@@ -24,7 +24,7 @@ class MutableParametersDetector : ComposableFunctionDetector(), SourceCodeScanne
           """
               Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
               Mutable objects that are not observable, such as `ArrayList<T>` or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-              See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information.
+              See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information.
             """,
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/KtCallableDeclarations.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/KtCallableDeclarations.kt
@@ -29,7 +29,6 @@ val KnownMutableCommonTypesRegex =
       "Hashtable<.*>\\??",
       // Compose
       "MutableState<.*>\\??",
-      "SnapshotStateList<.*>\\??",
       // Flow
       "MutableStateFlow<.*>\\??",
       "MutableSharedFlow<.*>\\??",

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
@@ -16,18 +16,19 @@ class MutableParametersDetectorTest : BaseSlackLintTest() {
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> =
-      arrayOf(
-          TestMode.PARENTHESIZED,
-          TestMode.SUPPRESSIBLE,
-          TestMode.TYPE_ALIAS,
-          TestMode.FULLY_QUALIFIED,
-          TestMode.WHITESPACE)
+    arrayOf(
+      TestMode.PARENTHESIZED,
+      TestMode.SUPPRESSIBLE,
+      TestMode.TYPE_ALIAS,
+      TestMode.FULLY_QUALIFIED,
+      TestMode.WHITESPACE
+    )
 
   @Test
   fun `errors when a Composable has a mutable parameter`() {
     @Language("kotlin")
     val code =
-        """
+      """
         @Composable
         fun Something(a: MutableState<String>) {}
         @Composable
@@ -37,13 +38,13 @@ class MutableParametersDetectorTest : BaseSlackLintTest() {
         @Composable
         fun Something(a: MutableMap<String, String>) {}
       """
-            .trimIndent()
+        .trimIndent()
     lint()
-        .files(kotlin(code))
-        .allowCompilationErrors()
-        .run()
-        .expect(
-            """
+      .files(kotlin(code))
+      .allowCompilationErrors()
+      .run()
+      .expect(
+        """
           src/test.kt:2: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
           See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
@@ -66,20 +67,21 @@ class MutableParametersDetectorTest : BaseSlackLintTest() {
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~
           4 errors, 0 warnings
         """
-                .trimIndent())
+          .trimIndent()
+      )
   }
 
   @Test
   fun `no errors when a Composable has valid parameters`() {
     @Language("kotlin")
     val code =
-        """
+      """
         @Composable
         fun Something(a: String, b: (Int) -> Unit) {}
         @Composable
         fun Something(a: State<String>) {}
       """
-            .trimIndent()
+        .trimIndent()
     lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
   }
 }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
@@ -16,19 +16,18 @@ class MutableParametersDetectorTest : BaseSlackLintTest() {
 
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> =
-    arrayOf(
-      TestMode.PARENTHESIZED,
-      TestMode.SUPPRESSIBLE,
-      TestMode.TYPE_ALIAS,
-      TestMode.FULLY_QUALIFIED,
-      TestMode.WHITESPACE
-    )
+      arrayOf(
+          TestMode.PARENTHESIZED,
+          TestMode.SUPPRESSIBLE,
+          TestMode.TYPE_ALIAS,
+          TestMode.FULLY_QUALIFIED,
+          TestMode.WHITESPACE)
 
   @Test
   fun `errors when a Composable has a mutable parameter`() {
     @Language("kotlin")
     val code =
-      """
+        """
         @Composable
         fun Something(a: MutableState<String>) {}
         @Composable
@@ -38,50 +37,49 @@ class MutableParametersDetectorTest : BaseSlackLintTest() {
         @Composable
         fun Something(a: MutableMap<String, String>) {}
       """
-        .trimIndent()
+            .trimIndent()
     lint()
-      .files(kotlin(code))
-      .allowCompilationErrors()
-      .run()
-      .expect(
-        """
+        .files(kotlin(code))
+        .allowCompilationErrors()
+        .run()
+        .expect(
+            """
           src/test.kt:2: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-          See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeMutableParameters]
+          See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
           fun Something(a: MutableState<String>) {}
-              ~~~~~~~~~
+                           ~~~~~~~~~~~~~~~~~~~~
           src/test.kt:4: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-          See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeMutableParameters]
+          See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
           fun Something(a: ArrayList<String>) {}
-              ~~~~~~~~~
+                           ~~~~~~~~~~~~~~~~~
           src/test.kt:6: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-          See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeMutableParameters]
+          See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
           fun Something(a: HashSet<String>) {}
-              ~~~~~~~~~
+                           ~~~~~~~~~~~~~~~
           src/test.kt:8: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-          See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeMutableParameters]
+          See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
           fun Something(a: MutableMap<String, String>) {}
-              ~~~~~~~~~
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
           4 errors, 0 warnings
         """
-          .trimIndent()
-      )
+                .trimIndent())
   }
 
   @Test
   fun `no errors when a Composable has valid parameters`() {
     @Language("kotlin")
     val code =
-      """
+        """
         @Composable
         fun Something(a: String, b: (Int) -> Unit) {}
         @Composable
         fun Something(a: State<String>) {}
       """
-        .trimIndent()
+            .trimIndent()
     lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
   }
 }


### PR DESCRIPTION
Resolves #48

~Still an open question here about why snapshot state collections aren't allowed here: https://github.com/slackhq/compose-lints/issues/48#issuecomment-1425098088~ Removed SnapshotStateList!

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->