### PR TITLE
Downgrade ComposeCompositionLocalUsage to warning

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/CompositionLocalUsageDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/CompositionLocalUsageDetector.kt
@@ -43,7 +43,7 @@ class CompositionLocalUsageDetector : Detector(), SourceCodeScanner {
             """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
-          severity = Severity.ERROR,
+          severity = Severity.WARNING,
           implementation = sourceImplementation<CompositionLocalUsageDetector>()
         )
         .setOptions(listOf(ALLOW_LIST))

--- a/compose-lint-checks/src/test/java/slack/lint/compose/CompositionLocalUsageDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/CompositionLocalUsageDetectorTest.kt
@@ -23,7 +23,7 @@ class CompositionLocalUsageDetectorTest : BaseSlackLintTest() {
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.PARENTHESIZED)
 
   @Test
-  fun `error when a CompositionLocal is defined`() {
+  fun `warning when a CompositionLocal is defined`() {
     lint()
       .files(
         kotlin(
@@ -37,27 +37,27 @@ class CompositionLocalUsageDetectorTest : BaseSlackLintTest() {
       )
       .allowCompilationErrors()
       .run()
-      .expectErrorCount(4)
+      .expectWarningCount(4)
       .expect(
         """
-        src/test.kt:2: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+        src/test.kt:2: Warning: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
         See https://slackhq.github.io/compose-lints/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         private val LocalApple = staticCompositionLocalOf<String> { "Apple" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test.kt:3: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+        src/test.kt:3: Warning: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
         See https://slackhq.github.io/compose-lints/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test.kt:4: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+        src/test.kt:4: Warning: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
         See https://slackhq.github.io/compose-lints/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         val LocalPrune = compositionLocalOf { "Prune" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test.kt:5: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+        src/test.kt:5: Warning: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
         See https://slackhq.github.io/compose-lints/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        4 errors, 0 warnings
-      """
+        0 errors, 4 warnings
+        """
           .trimIndent()
       )
   }
@@ -68,9 +68,9 @@ class CompositionLocalUsageDetectorTest : BaseSlackLintTest() {
       .files(
         kotlin(
           """
-                val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
-                val LocalPotato = compositionLocalOf { "Potato" }
-            """
+          val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
+          val LocalPotato = compositionLocalOf { "Potato" }
+          """
         )
       )
       .allowCompilationErrors()


### PR DESCRIPTION
Showing an error is too strong for developers using a `CompositionLocal`. We could even downgrade this to
`INFORMATIONAL`, but warning is fine for now.