### PR TITLE
Use setEnableByDefault instead for M2ApiDetector

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/M2ApiDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/M2ApiDetector.kt
@@ -6,7 +6,7 @@ import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
-import com.android.tools.lint.detector.api.Severity.IGNORE
+import com.android.tools.lint.detector.api.Severity.ERROR
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.StringOption
 import com.android.tools.lint.detector.api.TextFormat
@@ -47,10 +47,11 @@ constructor(private val allowList: StringSetLintOption = StringSetLintOption(ALL
             """,
           category = CORRECTNESS,
           priority = NORMAL,
-          severity = IGNORE,
+          severity = ERROR,
           implementation = sourceImplementation<M2ApiDetector>()
         )
         .setOptions(listOf(ALLOW_LIST))
+        .setEnabledByDefault(false)
   }
 
   override fun getApplicableUastTypes() =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/M2ApiDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/M2ApiDetectorTest.kt
@@ -97,23 +97,23 @@ class M2ApiDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:9: Warning: Compose Material 2 (M2) is succeeded by Material 3 (M3). Please use M3 APIs.
+          src/test.kt:9: Error: Compose Material 2 (M2) is succeeded by Material 3 (M3). Please use M3 APIs.
           See https://slackhq.github.io/compose-lints/rules/#use-material-3 for more information. [ComposeM2Api]
             Text("Hello, world!")
             ~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:23: Warning: Compose Material 2 (M2) is succeeded by Material 3 (M3). Please use M3 APIs.
+          src/test.kt:23: Error: Compose Material 2 (M2) is succeeded by Material 3 (M3). Please use M3 APIs.
           See https://slackhq.github.io/compose-lints/rules/#use-material-3 for more information. [ComposeM2Api]
               Text("Hello, world!")
               ~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:24: Warning: Compose Material 2 (M2) is succeeded by Material 3 (M3). Please use M3 APIs.
+          src/test.kt:24: Error: Compose Material 2 (M2) is succeeded by Material 3 (M3). Please use M3 APIs.
           See https://slackhq.github.io/compose-lints/rules/#use-material-3 for more information. [ComposeM2Api]
               val elevation = BottomNavigationDefaults.Elevation
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:25: Warning: Compose Material 2 (M2) is succeeded by Material 3 (M3). Please use M3 APIs.
+          src/test.kt:25: Error: Compose Material 2 (M2) is succeeded by Material 3 (M3). Please use M3 APIs.
           See https://slackhq.github.io/compose-lints/rules/#use-material-3 for more information. [ComposeM2Api]
               val drawerValue = BottomDrawerValue.Closed
                                 ~~~~~~~~~~~~~~~~~~~~~~~~
-          0 errors, 4 warnings
+          4 errors, 0 warnings
         """
           .trimIndent()
       )

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -302,20 +302,20 @@ Rule: [`ComposeM2Api`](https://github.com/slackhq/compose-lints/blob/main/compos
 Material 3 (M3) reached stable in October 2022. In apps that have migrated to M3, there may be `androidx.compose.material` (M2) APIs still remaining on the classpath from libraries or dependencies that can cause confusing imports due to the many similar or colliding Composable names in the two libraries. The `ComposeM2Api` rule can prevent these from being used.
 
 !!! warning "Lint Configuration"
-    This rule is set to `IGNORE` by default and is **opt-in**.
+    This rule is disabled default and is **opt-in**.
     
-    You can make it an error via the `lint` DSL in Gradle:
+    You can enable it via the `lint` DSL in Gradle:
     ```kotlin
     android {
       lint {
-        error += "ComposeM2Api"
+        enable += "ComposeM2Api"
       }
     }
     ```
     Or in `lint.xml`:
     ```xml
     <lint>
-      <issue id="ComposeM2Api" severity="error" />
+      <issue id="ComposeM2Api" severity="error"/>
     </lint>
     ```
     More lint configuration docs can be found [here](https://developer.android.com/studio/write/lint#gradle).
@@ -323,7 +323,7 @@ Material 3 (M3) reached stable in October 2022. In apps that have migrated to M3
 !!! note "Allow-list Configuration"
     To allow certain APIs (i.e. for incremental migration), you can configure a `allowed-m2-apis` option in `lint.xml`.
     ```xml
-    <issue id="ComposeM2Api">
+    <issue id="ComposeM2Api"  severity="error">
        <option name="allowed-m2-apis" value="Text,Surface" />
     </issue>
     ```


### PR DESCRIPTION
Resolves #80. Somewhat misleading from the lint API to say that severity isn't valid since it's one of the listed ones, but this better accomplishes the initial goal. One thing I'm not sure about is how to enable in `lint.xml` with this, and sort of assuming it's by just listing the issue in it with a severity.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->