### PR TITLE
Allow nullable types for trailing lambdas in ComposeParameterOrder

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -10,6 +10,7 @@ import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtParameter
 import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isModifier
@@ -97,5 +98,10 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
   }
 
   private val KtFunction.hasTrailingFunction: Boolean
-    get() = valueParameters.lastOrNull()?.typeReference?.typeElement is KtFunctionType
+    get() =
+      when (val outerType = valueParameters.lastOrNull()?.typeReference?.typeElement) {
+        is KtFunctionType -> true
+        is KtNullableType -> outerType.innerType is KtFunctionType
+        else -> false
+      }
 }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
@@ -33,6 +33,9 @@ class ParameterOrderDetectorTest : BaseSlackLintTest() {
 
         @Composable
         fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
+
+        @Composable
+        fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
       """
         .trimIndent()
     lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()


### PR DESCRIPTION
Fixed upstream in https://github.com/mrmans0n/compose-rules/pull/61

Functional types weren't being taken into account when computing the desired order of parameters in composables when the function was nullable. This fix addressed that by, in that case, targeting the innerType of the KtNullableType.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->