### PR TITLE
Ignore context receivers in multiple content emissions lint

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
@@ -96,6 +96,10 @@ constructor(
             // things like
             // BoxScope which are legit, and we want to avoid false positives.
             .filter { it.hasBlockBody() }
+            // Same applies to context receivers: we could have a BoxScope/ColumnScope/RowScope
+            // and it'd be legit.
+            // We don't have a way to know for sure, so we'd better avoid the issue altogether.
+            .filter { it.contextReceivers.isEmpty() }
             // We want only methods with a body
             .filterNot { it.hasReceiverType }
 

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
@@ -66,6 +66,28 @@ class MultipleContentEmittersDetectorTest : BaseSlackLintTest() {
   }
 
   @Test
+  fun `passes when the composable is a context receiver`() {
+    @Language("kotlin")
+    val code =
+      """
+        context(ColumnScope)
+        @Composable
+        fun Something() {
+            Text("Hi")
+            Text("Hola")
+        }
+        context(RowScope)
+        @Composable
+        fun Something() {
+            Spacer16()
+            Text("Hola")
+        }
+      """
+        .trimIndent()
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+
+  @Test
   fun `errors when a Composable function has more than one UI emitter at the top level`() {
     @Language("kotlin")
     val code =


### PR DESCRIPTION
Context receivers might make explicit the parent composable, like extension functions can do. As we can't know for sure whether the context receiver does contain something like a BoxScope/RowScope/ColumnScope or similar, we'd better ignore composables with context receivers for this rule, just to prevent false positives.

Fixes #129 
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->