### PR TITLE
Fix allowed names for Unit-returning functions

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposableFunctionNamingDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposableFunctionNamingDetector.kt
@@ -75,12 +75,13 @@ constructor(
     val functionName = function.name?.takeUnless(String::isEmpty) ?: return
     val firstLetter = functionName.first()
 
+    // If it's allowed, we don't report it
+    val isAllowed = allowedNames.value.any { it.toRegex().matches(functionName) }
+    if (isAllowed) return
+
     if (function.returnsValue) {
       // If it returns value, the composable should start with a lowercase letter
       if (firstLetter.isUpperCase()) {
-        // If it's allowed, we don't report it
-        val isAllowed = allowedNames.value.any { it.toRegex().matches(functionName) }
-        if (isAllowed) return
         context.report(
           ISSUE_LOWERCASE,
           function,

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ComposableFunctionNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ComposableFunctionNamingDetectorTest.kt
@@ -66,6 +66,20 @@ class ComposableFunctionNamingDetectorTest : BaseSlackLintTest() {
   }
 
   @Test
+  fun `passes when a composable that returns nothing or Unit is lowercase but allowed`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun myPresenter() { }
+        @Composable
+        fun myPresenter(): Unit { }
+      """
+        .trimIndent()
+    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+  }
+
+  @Test
   fun `passes when a composable doesn't have a body block, is a property or a lambda`() {
     @Language("kotlin")
     val code =


### PR DESCRIPTION
The allowed names for the naming detector were only being checked for compsable functions that returned a value. For functions that return nothing or Unit, the allowed names would have no effect.