### PR TITLE
Slight Improvement for rules documentation 

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -74,7 +74,7 @@ If a composable should offer additional control surfaces to its caller, those co
 
 More info: [Compose API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#emit-xor-return-a-value)
 
-Related rule: [`ComposeMultipleContentEmitters`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt)
+Related rule: [`ComposeContentEmitterReturningValues`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ContentEmitterReturningValuesDetector.kt)
 
 !!! note "Configuration"
     To add your custom composables so they are used in this rule (things like your design system composables), you can configure a `content-emitters` option in `lint.xml`.


### PR DESCRIPTION
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->
In the rules documentation the related rule for  "Do not emit content and return a result" was referencing the wrong rule. Instead of `ComposeContentEmitterReturningValues`. [issue](https://github.com/slackhq/compose-lints/issues/169)
