### PR TITLE
Add support for checking for loops in multiple content emitters

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
@@ -43,7 +43,7 @@ constructor(
           explanation =
             """
               Composable functions should only be emitting content into the composition from one source at their top level.
-              
+
               See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information.
             """,
           category = Category.PRODUCTIVITY,
@@ -59,39 +59,36 @@ constructor(
       return bodyBlockExpression?.let { block ->
         // If there's content emitted in a for loop, we assume there's at
         // least two iterations and thus count any emitters in them as multiple
-        val forLoopCount = if (block.forLoopHasUiEmitters) {
-          2
-        } else {
-          0
-        }
+        val forLoopCount =
+          if (block.forLoopHasUiEmitters) {
+            2
+          } else {
+            0
+          }
         block.directUiEmitterCount + forLoopCount
       } ?: 0
     }
 
   internal val KtBlockExpression.forLoopHasUiEmitters: Boolean
     get() {
-      return statements
-        .filterIsInstance<KtForExpression>()
-        .any {
-          when (val body = it.body) {
-            is KtBlockExpression -> {
-              body.directUiEmitterCount > 0
-            }
-            is KtCallExpression -> {
-              body.emitsContent(contentEmitterOption.value)
-            }
-            else -> false
+      return statements.filterIsInstance<KtForExpression>().any {
+        when (val body = it.body) {
+          is KtBlockExpression -> {
+            body.directUiEmitterCount > 0
           }
+          is KtCallExpression -> {
+            body.emitsContent(contentEmitterOption.value)
+          }
+          else -> false
         }
+      }
     }
 
   internal val KtBlockExpression.directUiEmitterCount: Int
     get() {
-      return statements
-        .filterIsInstance<KtCallExpression>()
-        .count {
-          it.emitsContent(contentEmitterOption.value)
-        }
+      return statements.filterIsInstance<KtCallExpression>().count {
+        it.emitsContent(contentEmitterOption.value)
+      }
     }
 
   internal fun KtFunction.indirectUiEmitterCount(mapping: Map<KtFunction, Int>): Int {

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
@@ -110,10 +110,14 @@ class MultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
-          src/test.kt:6: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:6: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           2 errors, 0 warnings
@@ -157,10 +161,14 @@ class MultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:5: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:5: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
-          src/test.kt:18: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:18: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           2 errors, 0 warnings
@@ -192,7 +200,9 @@ class MultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           1 errors, 0 warnings

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
@@ -200,4 +200,46 @@ class MultipleContentEmittersDetectorTest : BaseSlackLintTest() {
           .trimIndent()
       )
   }
+
+  @Test
+  fun `for loops are captured`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun MultipleContent(texts: List<String>, modifier: Modifier = Modifier) {
+            for (text in texts) {
+                Text(text)
+            }
+        }
+        @Composable
+        fun MultipleContent(otherTexts: List<String>, modifier: Modifier = Modifier) {
+            Text("text 1")
+            for (otherText in otherTexts) {
+                Text(otherText)
+            }
+        }
+      """
+        .trimIndent()
+    lint()
+      .files(kotlin(code))
+      .allowCompilationErrors()
+      .run()
+      .expect(
+        """
+          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          @Composable
+          ^
+          src/test.kt:7: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          @Composable
+          ^
+          2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
 }


### PR DESCRIPTION
Resolves #197. It's a superficial check that only covers top-level for loops, but an improvement over before