### PR TITLE
Improve the parameter order check

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -88,11 +88,18 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
     // If it's not the same as the current order, we show the rule violation.
     if (currentOrder != properOrder) {
+      val errorLocation = context.getLocation(function.valueParameterList)
       context.report(
         ISSUE,
         function,
-        context.getLocation(function.valueParameterList),
-        createErrorMessage(currentOrder, properOrder)
+        errorLocation,
+        createErrorMessage(currentOrder, properOrder),
+        fix()
+          .replace()
+          .range(errorLocation)
+          .with("(${properOrder.joinToString { it.text }})")
+          .reformat(true)
+          .build()
       )
     }
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -97,7 +97,7 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
         fix()
           .replace()
           .range(errorLocation)
-          .with("(${properOrder.joinToString { it.text }})")
+          .with(properOrder.joinToString(prefix = "(", postfix = ")") { it.text })
           .reformat(true)
           .build()
       )

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -29,7 +29,7 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
         properOrder.joinToString { it.text }
       )
 
-    fun createErrorMessage(currentOrder: String, properOrder: String): String =
+    private fun createErrorMessage(currentOrder: String, properOrder: String): String =
       """
         Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
         Current params are: [$currentOrder] but should be [$properOrder].
@@ -91,7 +91,7 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
       context.report(
         ISSUE,
         function,
-        context.getLocation(function),
+        context.getLocation(function.valueParameterList),
         createErrorMessage(currentOrder, properOrder)
       )
     }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
@@ -98,4 +98,56 @@ class ParameterOrderDetectorTest : BaseSlackLintTest() {
           .trimIndent()
       )
   }
+
+  @Test
+  fun `errors fixed when ordering is wrong`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun MyComposable(modifier: Modifier = Modifier, other: String, other2: String) { }
+
+        @Composable
+        fun MyComposable(text: String = "deffo", modifier: Modifier = Modifier) { }
+
+        @Composable
+        fun MyComposable(modifier: Modifier = Modifier, text: String = "123", modifier2: Modifier = Modifier) { }
+
+        @Composable
+        fun MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) { }
+
+        @Composable
+        fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
+      """
+        .trimIndent()
+    lint()
+      .files(kotlin(code))
+      .allowCompilationErrors()
+      .run()
+      .expectFixDiffs(
+        """
+                Fix for src/test.kt line 2: Replace with (other: String, other2: String, modifier: Modifier = Modifier):
+                @@ -2 +2
+                - fun MyComposable(modifier: Modifier = Modifier, other: String, other2: String) { }
+                + fun MyComposable(other: String, other2: String, modifier: Modifier = Modifier) { }
+                Fix for src/test.kt line 5: Replace with (modifier: Modifier = Modifier, text: String = "deffo"):
+                @@ -5 +5
+                - fun MyComposable(text: String = "deffo", modifier: Modifier = Modifier) { }
+                + fun MyComposable(modifier: Modifier = Modifier, text: String = "deffo") { }
+                Fix for src/test.kt line 8: Replace with (modifier: Modifier = Modifier, modifier2: Modifier = Modifier, text: String = "123"):
+                @@ -8 +8
+                - fun MyComposable(modifier: Modifier = Modifier, text: String = "123", modifier2: Modifier = Modifier) { }
+                + fun MyComposable(modifier: Modifier = Modifier, modifier2: Modifier = Modifier, text: String = "123") { }
+                Fix for src/test.kt line 11: Replace with (modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit):
+                @@ -11 +11
+                - fun MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) { }
+                + fun MyComposable(modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit) { }
+                Fix for src/test.kt line 14: Replace with (text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit):
+                @@ -14 +14
+                - fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
+                + fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
+                """
+          .trimIndent()
+      )
+  }
 }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
@@ -68,31 +68,31 @@ class ParameterOrderDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          src/test.kt:2: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [modifier: Modifier = Modifier, other: String, other2: String] but should be [other: String, other2: String, modifier: Modifier = Modifier].
           See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
-          @Composable
-          ^
-          src/test.kt:4: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          fun MyComposable(modifier: Modifier = Modifier, other: String, other2: String) { }
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          src/test.kt:5: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [text: String = "deffo", modifier: Modifier = Modifier] but should be [modifier: Modifier = Modifier, text: String = "deffo"].
           See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
-          @Composable
-          ^
-          src/test.kt:7: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          fun MyComposable(text: String = "deffo", modifier: Modifier = Modifier) { }
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          src/test.kt:8: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [modifier: Modifier = Modifier, text: String = "123", modifier2: Modifier = Modifier] but should be [modifier: Modifier = Modifier, modifier2: Modifier = Modifier, text: String = "123"].
           See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
-          @Composable
-          ^
-          src/test.kt:10: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          fun MyComposable(modifier: Modifier = Modifier, text: String = "123", modifier2: Modifier = Modifier) { }
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          src/test.kt:11: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit] but should be [modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit].
           See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
-          @Composable
-          ^
-          src/test.kt:13: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          fun MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) { }
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          src/test.kt:14: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit] but should be [text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit].
           See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
-          @Composable
-          ^
+          fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           5 errors, 0 warnings
         """
           .trimIndent()


### PR DESCRIPTION
The current implementation of this inspection marks the entire function (including the body) as the error site, when this check is only concerned with the parameter list. This leads to very loud errors that are not obviously indicated from the often large quantity of error highlighting in the editor.

Instead, the error should report its location as the parameter list for more precision and ultimately a better indication of the error.

This also adds a quick fix to this detector.
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->