### PR TITLE
Add testDocumentationExample

### DIFF
--- a/compose-lint-checks/src/test/java/slack/lint/compose/ComposableFunctionNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ComposableFunctionNamingDetectorTest.kt
@@ -24,6 +24,54 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+
+        @Composable
+        fun myComposable() { }
+
+        @Composable
+        fun myComposable(): Unit { }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/test.kt:4: Error: Composable functions that return Unit should start with an uppercase letter.They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.See https://slackhq.github.io/compose-lints/rules/#naming-composable-functions-properly for more information. [ComposeNamingUppercase]
+          fun myComposable() { }
+              ~~~~~~~~~~~~
+          src/test.kt:7: Error: Composable functions that return Unit should start with an uppercase letter.They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.See https://slackhq.github.io/compose-lints/rules/#naming-composable-functions-properly for more information. [ComposeNamingUppercase]
+          fun myComposable(): Unit { }
+              ~~~~~~~~~~~~
+          2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `passes when a composable returns nothing or Unit and is lowercase but has a receiver`() {
+    @Language("kotlin")
+    val code =
+      """
+        @Composable
+        fun Potato.myComposable() { }
+
+        @Composable
+        fun Banana.myComposable(): Unit { }
+      """
+        .trimIndent()
+
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
   fun `passes when a composable that returns values is lowercase`() {
     @Language("kotlin")
     val code =
@@ -32,7 +80,7 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
         fun myComposable(): Something { }
       """
         .trimIndent()
-    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
 
   @Test
@@ -44,7 +92,7 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
         fun ProfilePresenter(): Something { }
       """
         .trimIndent()
-    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
 
   @Test
@@ -58,7 +106,7 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
         fun MyComposable(): Unit { }
       """
         .trimIndent()
-    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
 
   @Test
@@ -72,7 +120,7 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
         fun myPresenter(): Unit { }
       """
         .trimIndent()
-    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
 
   @Test
@@ -92,7 +140,7 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
         val whatever = @Composable { }
       """
         .trimIndent()
-    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
 
   @Test
@@ -150,44 +198,5 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
         """
           .trimIndent()
       )
-    // TODO see above
-    //      .expect(
-    //        testMode = TestMode.TYPE_ALIAS,
-    //        expectedText =
-    //        """
-    //          src/test.kt:2: Error: Composable functions that return Unit should start with an
-    // uppercase letter.They are considered declarative entities that can be either present or
-    // absent in a composition and therefore follow the naming rules for classes.See
-    // https://slackhq.github.io/compose-lints/rules/#naming-composable-functions-properly for more
-    // information. [ComposeNamingUppercase]
-    //          fun myComposable() { }
-    //              ~~~~~~~~~~~~
-    //          src/test.kt:5: Error: Composable functions that return Unit should start with an
-    // uppercase letter.They are considered declarative entities that can be either present or
-    // absent in a composition and therefore follow the naming rules for classes.See
-    // https://slackhq.github.io/compose-lints/rules/#naming-composable-functions-properly for more
-    // information. [ComposeNamingUppercase]
-    //          fun myComposable(): TYPE_ALIAS_1 { }
-    //              ~~~~~~~~~~~~
-    //          2 errors, 0 warnings
-    //        """
-    //          .trimIndent()
-    //      )
-  }
-
-  @Test
-  fun `passes when a composable returns nothing or Unit and is lowercase but has a receiver`() {
-    @Language("kotlin")
-    val code =
-      """
-        @Composable
-        fun Potato.myComposable() { }
-
-        @Composable
-        fun Banana.myComposable(): Unit { }
-      """
-        .trimIndent()
-
-    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
   }
 }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ComposableFunctionNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ComposableFunctionNamingDetectorTest.kt
@@ -24,7 +24,7 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
-  fun testDocumentationExample() {
+  fun testDocumentationExampleComposeNamingUppercase() {
     @Language("kotlin")
     val code =
       """
@@ -50,6 +50,31 @@ class ComposableFunctionNamingDetectorTest : BaseComposeLintTest() {
           fun myComposable(): Unit { }
               ~~~~~~~~~~~~
           2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun testDocumentationExampleComposeNamingLowercase() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+
+        @Composable
+        fun MyComposable(): Something { }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/test.kt:4: Error: Composable functions that return a value should start with a lowercase letter.While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.See https://slackhq.github.io/compose-lints/rules/#naming-composable-functions-properly for more information. [ComposeNamingLowercase]
+          fun MyComposable(): Something { }
+              ~~~~~~~~~~~~
+          1 errors, 0 warnings
         """
           .trimIndent()
       )


### PR DESCRIPTION
So a neat feature @tnorbye told me about recently is that adding a test with the name `testDocumentationExample` will automatically index as a sample error on the lint docs site (which index our lints!)

This is a little test of that to see if it shows up here:
- https://googlesamples.github.io/android-custom-lint-rules/checks/ComposeNamingLowercase.md.html
- https://googlesamples.github.io/android-custom-lint-rules/checks/ComposeNamingUppercase.md.html

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->