### PR TITLE
Implement UnstableReceiverDetector

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposableFunctionDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposableFunctionDetector.kt
@@ -8,6 +8,7 @@ import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.isKotlin
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.uast.UMethod
 import slack.lint.compose.util.LintOption
 import slack.lint.compose.util.OptionLoadingDetector
@@ -23,12 +24,28 @@ abstract class ComposableFunctionDetector(vararg options: LintOption) :
     return object : UElementHandler() {
       override fun visitMethod(node: UMethod) {
         if (node.isComposable) {
-          val ktFunction = node.sourcePsi as? KtFunction ?: return
-          visitComposable(context, node, ktFunction)
+          visitComposable(context, node)
+          when (val sourcePsi = node.sourcePsi ?: return) {
+            is KtPropertyAccessor -> {
+              visitComposable(context, node, sourcePsi)
+            }
+
+            is KtFunction -> {
+              visitComposable(context, node, sourcePsi)
+            }
+          }
         }
       }
     }
   }
 
-  abstract fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction)
+  open fun visitComposable(context: JavaContext, method: UMethod) {
+  }
+
+  open fun visitComposable(context: JavaContext, method: UMethod, property: KtPropertyAccessor) {
+  }
+
+  open fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
+
+  }
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposableFunctionDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposableFunctionDetector.kt
@@ -29,7 +29,6 @@ abstract class ComposableFunctionDetector(vararg options: LintOption) :
             is KtPropertyAccessor -> {
               visitComposable(context, node, sourcePsi)
             }
-
             is KtFunction -> {
               visitComposable(context, node, sourcePsi)
             }
@@ -39,13 +38,9 @@ abstract class ComposableFunctionDetector(vararg options: LintOption) :
     }
   }
 
-  open fun visitComposable(context: JavaContext, method: UMethod) {
-  }
+  open fun visitComposable(context: JavaContext, method: UMethod) {}
 
-  open fun visitComposable(context: JavaContext, method: UMethod, property: KtPropertyAccessor) {
-  }
+  open fun visitComposable(context: JavaContext, method: UMethod, property: KtPropertyAccessor) {}
 
-  open fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
-
-  }
+  open fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {}
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
@@ -42,5 +42,6 @@ class ComposeLintsIssueRegistry : IssueRegistry() {
       ViewModelForwardingDetector.ISSUE,
       ViewModelInjectionDetector.ISSUE,
       ModifierComposedDetector.ISSUE,
+      UnstableReceiverDetector.ISSUE,
     )
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -17,6 +17,7 @@ import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UParameter
 import org.jetbrains.uast.toUElementOfType
 import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.isFunctionalInterface
 import slack.lint.compose.util.isModifier
 import slack.lint.compose.util.runIf
 import slack.lint.compose.util.sourceImplementation
@@ -118,7 +119,6 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
     val resolved =
       evaluator.getTypeClass(valueParameters.lastOrNull()?.toUElementOfType<UParameter>()?.type)
         ?: return false
-    return resolved.hasAnnotation("java.lang.FunctionalInterface") ||
-      resolved.qualifiedName?.startsWith("kotlin.jvm.functions.") == true
+    return resolved.isFunctionalInterface
   }
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
@@ -1,0 +1,98 @@
+// Copyright (C) 2023 Salesforce, Inc.
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiType
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.psiUtil.isTopLevelKtOrJavaMember
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.getContainingUClass
+import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.isStable
+import slack.lint.compose.util.sourceImplementation
+
+class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner {
+  companion object {
+    val ISSUE =
+      Issue.create(
+        id = "ComposeUnstableReceiver",
+        briefDescription = "Unstable receivers will always be recomposed",
+        explanation =
+        """
+              Instance composable functions on non-stable classes will always be recomposed. \
+              If possible, make the receiver type stable or refactor this function if that isn't possible. \
+              See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information.
+            """,
+        category = Category.PRODUCTIVITY,
+        priority = Priorities.NORMAL,
+        severity = Severity.WARNING,
+        implementation = sourceImplementation<UnstableReceiverDetector>(),
+      )
+  }
+
+  override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
+    // Not implemented as we want properties too
+  }
+
+  override fun visitComposable(context: JavaContext, method: UMethod) {
+    lateinit var nodeToReport: KtTypeReference
+    val receiverParam = method.uastParameters.firstOrNull()
+    val receiverType: PsiType? = when (val source = method.sourcePsi) {
+      is KtFunction -> {
+        source.receiverTypeReference?.let {
+          nodeToReport = it
+          // Receiver is the first uastParameter
+          receiverParam?.type
+        }
+      }
+
+      is KtPropertyAccessor -> {
+        source.property.receiverTypeReference?.let {
+          nodeToReport = it
+          // Receiver is the first uastParameter
+          receiverParam?.type
+        }
+      }
+
+      else -> null
+    }
+
+    if (receiverType?.isStable(context.evaluator) == false) {
+      context.report(
+        ISSUE,
+        nodeToReport,
+        context.getLocation(nodeToReport),
+        ISSUE.getExplanation(TextFormat.TEXT),
+      )
+    } else if (!method.isTopLevelKtOrJavaMember() && !method.isStatic) {
+      // We check both the receiver and the containing class, as classes could have
+      // extension functions in their declarations too.
+      val containingClass = method.getContainingUClass()
+      val containingClassType =
+        containingClass
+          // If the containing class is an object, it will never be passed as a receiver arg
+          ?.takeUnless { it.sourcePsi is KtObjectDeclaration }
+          ?.let(context.evaluator::getClassType)
+      if (containingClassType?.isStable(context.evaluator, resolveUClass = { containingClass }) == false) {
+        context.report(
+          ISSUE,
+          method,
+          context.getNameLocation(method),
+          ISSUE.getExplanation(TextFormat.TEXT),
+        )
+      }
+    }
+  }
+}

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
@@ -1,5 +1,4 @@
 // Copyright (C) 2023 Salesforce, Inc.
-// Copyright 2022 Twitter, Inc.
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
@@ -9,9 +8,7 @@ import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.TextFormat
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiType
-import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
@@ -30,7 +27,7 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
         id = "ComposeUnstableReceiver",
         briefDescription = "Unstable receivers will always be recomposed",
         explanation =
-        """
+          """
               Instance composable functions on non-stable classes will always be recomposed. \
               If possible, make the receiver type stable or refactor this function if that isn't possible. \
               See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information.
@@ -49,25 +46,24 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
   override fun visitComposable(context: JavaContext, method: UMethod) {
     lateinit var nodeToReport: KtTypeReference
     val receiverParam = method.uastParameters.firstOrNull()
-    val receiverType: PsiType? = when (val source = method.sourcePsi) {
-      is KtFunction -> {
-        source.receiverTypeReference?.let {
-          nodeToReport = it
-          // Receiver is the first uastParameter
-          receiverParam?.type
+    val receiverType: PsiType? =
+      when (val source = method.sourcePsi) {
+        is KtFunction -> {
+          source.receiverTypeReference?.let {
+            nodeToReport = it
+            // Receiver is the first uastParameter
+            receiverParam?.type
+          }
         }
-      }
-
-      is KtPropertyAccessor -> {
-        source.property.receiverTypeReference?.let {
-          nodeToReport = it
-          // Receiver is the first uastParameter
-          receiverParam?.type
+        is KtPropertyAccessor -> {
+          source.property.receiverTypeReference?.let {
+            nodeToReport = it
+            // Receiver is the first uastParameter
+            receiverParam?.type
+          }
         }
+        else -> null
       }
-
-      else -> null
-    }
 
     if (receiverType?.isStable(context.evaluator) == false) {
       context.report(
@@ -85,7 +81,10 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
           // If the containing class is an object, it will never be passed as a receiver arg
           ?.takeUnless { it.sourcePsi is KtObjectDeclaration }
           ?.let(context.evaluator::getClassType)
-      if (containingClassType?.isStable(context.evaluator, resolveUClass = { containingClass }) == false) {
+      if (
+        containingClassType?.isStable(context.evaluator, resolveUClass = { containingClass }) ==
+          false
+      ) {
         context.report(
           ISSUE,
           method,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
@@ -1,0 +1,86 @@
+// Copyright (C) 2024 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose.util
+
+import com.android.tools.lint.client.api.JavaEvaluator
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypes
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.toUElementOfType
+
+private const val COMPOSE_STABLE = "androidx.compose.runtime.Stable"
+private const val COMPOSE_IMMUTABLE = "androidx.compose.runtime.Immutable"
+private const val COMPOSE_STABLE_MARKER = "androidx.compose.runtime.StableMarker"
+
+val STABILITY_ANNOTATIONS = setOf(COMPOSE_STABLE, COMPOSE_IMMUTABLE)
+
+/**
+ * Sets of known external stable constructs to the compose-compiler.
+ *
+ * @see <a href="https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/KnownStableConstructs.kt">KnownStableConstructs</a>
+ */
+object KnownStableConstructs {
+
+  val stableTypes = setOf(
+    Pair::class.qualifiedName!!,
+    Triple::class.qualifiedName!!,
+    Comparator::class.qualifiedName!!,
+    Result::class.qualifiedName!!,
+    ClosedRange::class.qualifiedName!!,
+    ClosedFloatingPointRange::class.qualifiedName!!,
+    // Guava
+    "com.google.common.collect.ImmutableList",
+    "com.google.common.collect.ImmutableEnumMap",
+    "com.google.common.collect.ImmutableMap",
+    "com.google.common.collect.ImmutableEnumSet",
+    "com.google.common.collect.ImmutableSet",
+    // Kotlinx immutable
+    "kotlinx.collections.immutable.ImmutableCollection",
+    "kotlinx.collections.immutable.ImmutableList",
+    "kotlinx.collections.immutable.ImmutableSet",
+    "kotlinx.collections.immutable.ImmutableMap",
+    "kotlinx.collections.immutable.PersistentCollection",
+    "kotlinx.collections.immutable.PersistentList",
+    "kotlinx.collections.immutable.PersistentSet",
+    "kotlinx.collections.immutable.PersistentMap",
+    // Dagger
+    "dagger.Lazy",
+    // Coroutines
+    "kotlin.coroutines.EmptyCoroutineContext",
+  )
+}
+
+fun PsiType.isStable(
+  evaluator: JavaEvaluator,
+  resolveUClass: () -> UClass? = { evaluator.getTypeClass(this)?.toUElementOfType<UClass>() },
+): Boolean {
+  // Primitive types
+  when (this) {
+    PsiTypes.byteType(),
+    PsiTypes.charType(),
+    PsiTypes.doubleType(),
+    PsiTypes.floatType(),
+    PsiTypes.intType(),
+    PsiTypes.longType(),
+    PsiTypes.shortType(),
+    PsiTypes.booleanType(),
+    PsiTypes.voidType(),
+    -> return true
+  }
+  val resolved = resolveUClass() ?: return false
+
+  // Enums are stable
+  if (resolved.isEnum) return true
+  resolved.qualifiedName?.let { qualifiedName ->
+    if (qualifiedName == "java.lang.String") return true
+    if (qualifiedName in KnownStableConstructs.stableTypes) return true
+  }
+  if (resolved.isFunctionalInterface) return true
+  return resolved.uAnnotations.any {
+    // Is it itself a preview annotation?
+    it.resolve()?.let { cls ->
+      cls.qualifiedName in STABILITY_ANNOTATIONS ||
+        cls.hasAnnotation(COMPOSE_STABLE_MARKER)
+    } ?: false
+  }
+}

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
@@ -17,37 +17,39 @@ val STABILITY_ANNOTATIONS = setOf(COMPOSE_STABLE, COMPOSE_IMMUTABLE)
 /**
  * Sets of known external stable constructs to the compose-compiler.
  *
- * @see <a href="https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/KnownStableConstructs.kt">KnownStableConstructs</a>
+ * @see <a
+ *   href="https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/KnownStableConstructs.kt">KnownStableConstructs</a>
  */
 object KnownStableConstructs {
 
-  val stableTypes = setOf(
-    Pair::class.qualifiedName!!,
-    Triple::class.qualifiedName!!,
-    Comparator::class.qualifiedName!!,
-    Result::class.qualifiedName!!,
-    ClosedRange::class.qualifiedName!!,
-    ClosedFloatingPointRange::class.qualifiedName!!,
-    // Guava
-    "com.google.common.collect.ImmutableList",
-    "com.google.common.collect.ImmutableEnumMap",
-    "com.google.common.collect.ImmutableMap",
-    "com.google.common.collect.ImmutableEnumSet",
-    "com.google.common.collect.ImmutableSet",
-    // Kotlinx immutable
-    "kotlinx.collections.immutable.ImmutableCollection",
-    "kotlinx.collections.immutable.ImmutableList",
-    "kotlinx.collections.immutable.ImmutableSet",
-    "kotlinx.collections.immutable.ImmutableMap",
-    "kotlinx.collections.immutable.PersistentCollection",
-    "kotlinx.collections.immutable.PersistentList",
-    "kotlinx.collections.immutable.PersistentSet",
-    "kotlinx.collections.immutable.PersistentMap",
-    // Dagger
-    "dagger.Lazy",
-    // Coroutines
-    "kotlin.coroutines.EmptyCoroutineContext",
-  )
+  val stableTypes =
+    setOf(
+      Pair::class.qualifiedName!!,
+      Triple::class.qualifiedName!!,
+      Comparator::class.qualifiedName!!,
+      Result::class.qualifiedName!!,
+      ClosedRange::class.qualifiedName!!,
+      ClosedFloatingPointRange::class.qualifiedName!!,
+      // Guava
+      "com.google.common.collect.ImmutableList",
+      "com.google.common.collect.ImmutableEnumMap",
+      "com.google.common.collect.ImmutableMap",
+      "com.google.common.collect.ImmutableEnumSet",
+      "com.google.common.collect.ImmutableSet",
+      // Kotlinx immutable
+      "kotlinx.collections.immutable.ImmutableCollection",
+      "kotlinx.collections.immutable.ImmutableList",
+      "kotlinx.collections.immutable.ImmutableSet",
+      "kotlinx.collections.immutable.ImmutableMap",
+      "kotlinx.collections.immutable.PersistentCollection",
+      "kotlinx.collections.immutable.PersistentList",
+      "kotlinx.collections.immutable.PersistentSet",
+      "kotlinx.collections.immutable.PersistentMap",
+      // Dagger
+      "dagger.Lazy",
+      // Coroutines
+      "kotlin.coroutines.EmptyCoroutineContext",
+    )
 }
 
 fun PsiType.isStable(
@@ -64,8 +66,7 @@ fun PsiType.isStable(
     PsiTypes.longType(),
     PsiTypes.shortType(),
     PsiTypes.booleanType(),
-    PsiTypes.voidType(),
-    -> return true
+    PsiTypes.voidType() -> return true
   }
   val resolved = resolveUClass() ?: return false
 
@@ -79,8 +80,7 @@ fun PsiType.isStable(
   return resolved.uAnnotations.any {
     // Is it itself a preview annotation?
     it.resolve()?.let { cls ->
-      cls.qualifiedName in STABILITY_ANNOTATIONS ||
-        cls.hasAnnotation(COMPOSE_STABLE_MARKER)
+      cls.qualifiedName in STABILITY_ANNOTATIONS || cls.hasAnnotation(COMPOSE_STABLE_MARKER)
     } ?: false
   }
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Types.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Types.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose.util
 
 import com.intellij.psi.PsiClass

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Types.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Types.kt
@@ -1,0 +1,10 @@
+package slack.lint.compose.util
+
+import com.intellij.psi.PsiClass
+
+val PsiClass.isFunctionalInterface: Boolean
+  get() {
+    return hasAnnotation("java.lang.FunctionalInterface") ||
+      qualifiedName == "kotlin.Function" ||
+      qualifiedName?.startsWith("kotlin.jvm.functions.") == true
+  }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/BaseComposeLintTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/BaseComposeLintTest.kt
@@ -34,6 +34,12 @@ abstract class BaseComposeLintTest : LintDetectorTest() {
           package androidx.compose.runtime
 
           annotation class Composable
+          @Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
+          annotation class StableMarker
+          @StableMarker
+          annotation class Stable
+          @StableMarker
+          annotation class Immutable
 
           interface State<out T> {
               val value: T

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
@@ -1,0 +1,130 @@
+// Copyright (C) 2023 Salesforce, Inc.
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class UnstableReceiverDetectorTest : BaseComposeLintTest() {
+
+  override fun getDetector(): Detector = UnstableReceiverDetector()
+
+  override fun getIssues(): List<Issue> = listOf(UnstableReceiverDetector.ISSUE)
+
+  @Test
+  fun `stable receiver types report no errors`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.runtime.Stable
+        import androidx.compose.runtime.StableMarker
+
+        @StableMarker
+        annotation class CustomStable
+
+        @Stable
+        interface ExampleInterface {
+          @Composable fun Content()
+        }
+
+        @Stable
+        class Example {
+          @Composable fun Content() {}
+        }
+
+        @CustomStable
+        class CustomExample {
+          @Composable fun Content() {}
+        }
+
+        @Composable
+        fun Example.OtherContent() {}
+
+        @get:Composable
+        val Example.OtherContentProperty get() {}
+
+        @Stable
+        enum class EnumExample {
+          TEST;
+          @Composable fun Content() {}
+        }
+
+        @Composable
+        fun EnumExample.OtherContent() {}
+
+        @Stable
+        enum class EnumExample {
+          TEST;
+          @Composable fun Content() {}
+        }
+
+        @Composable
+        fun EnumExample.OtherContent() {}
+
+        // Primitives are ok
+        @Composable
+        fun String.OtherContent() {}
+        @Composable
+        fun Int.OtherContent() {}
+
+        // Functions are ok
+        @Composable
+        fun (() -> Unit).OtherContent() {}
+        @Composable
+        fun Function<String>.OtherContent() {}
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `unstable receiver types report errors`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+
+        interface ExampleInterface {
+          @Composable fun Content()
+        }
+
+        class Example {
+          @Composable fun Content() {}
+        }
+
+        @Composable
+        fun Example.OtherContent() {}
+
+        @get:Composable
+        val Example.OtherContentProperty get() {}
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/ExampleInterface.kt:4: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible. See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+            @Composable fun Content()
+                            ~~~~~~~
+          src/ExampleInterface.kt:8: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible. See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+            @Composable fun Content() {}
+                            ~~~~~~~
+          src/ExampleInterface.kt:12: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible. See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+          fun Example.OtherContent() {}
+              ~~~~~~~
+          src/ExampleInterface.kt:15: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible. See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+          val Example.OtherContentProperty get() {}
+              ~~~~~~~
+          0 errors, 4 warnings
+        """.trimIndent()
+      )
+  }
+}

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
@@ -1,5 +1,4 @@
 // Copyright (C) 2023 Salesforce, Inc.
-// Copyright 2022 Twitter, Inc.
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
@@ -78,10 +77,7 @@ class UnstableReceiverDetectorTest : BaseComposeLintTest() {
         fun Function<String>.OtherContent() {}
       """
         .trimIndent()
-    lint()
-      .files(*commonStubs, kotlin(code))
-      .run()
-      .expectClean()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
 
   @Test
@@ -124,7 +120,8 @@ class UnstableReceiverDetectorTest : BaseComposeLintTest() {
           val Example.OtherContentProperty get() {}
               ~~~~~~~
           0 errors, 4 warnings
-        """.trimIndent()
+        """
+          .trimIndent()
       )
   }
 }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -66,6 +66,15 @@ Passing `ArrayList<T>`, `MutableState<T>`, `ViewModel` are common examples of th
 
 Related rule: [`ComposeMutableParameters`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt)
 
+### Unstable receivers
+
+In compose, all parameters must be stable or immutable in order for a composable function to be
+_restartable_ or _skippable_. This _includes_ the containing class or receiver, which the compose-compiler will treat as the 0th argument. Using an unstable receiver is usually a bug, so this lint offers a warning to raise this issue.
+
+More info: [Compose API Stability](https://developer.android.com/jetpack/compose/performance/stability)
+
+Related rule: [`UnstableReceiverDetector`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt)
+
 ### Do not emit content and return a result
 
 Composable functions should either emit layout content, or return a value, but not both.


### PR DESCRIPTION
Resolves #172. Also adds some more hooks for composable property accessors.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->