### PR TITLE
Add support for checking inherited stability in UnstableReceiverDetector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 --------------
 
 - **New**: Implement `ModifierComposed` check to lint against use of `Modifier.composed`, which is no longer recommended in favor of the new `Modifier.Node` API.
-- **New**: Implement `ComposeUnstableReceiver` check to warn when composable extension functions or composables instance functions have unstable receivers/containing classes. 
+- **New**: Implement `ComposeUnstableReceiver` check to warn when composable extension functions or composables instance functions have unstable receivers/containing classes.
 - **Enhancement**: The `ComposeComposableModifier` message now recommends the new `Modifier.Node` API.
 - **Enhancement**: Make lints **significantly** more robust to edge cases like typealiases, import aliases, parentheses, fully-qualified references, and whitespace. Our tests now cover all these cases.
 - **Enhancement**: Update `@Preview` detection to also detect Compose Desktop's own `@Preview` annotation.

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
@@ -80,11 +80,9 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
         containingClass
           // If the containing class is an object, it will never be passed as a receiver arg
           ?.takeUnless { it.sourcePsi is KtObjectDeclaration }
-          ?.let(context.evaluator::getClassType)
-      if (
-        containingClassType?.isStable(context.evaluator, resolveUClass = { containingClass }) ==
-          false
-      ) {
+          ?.let(context.evaluator::getClassType) ?: return
+
+      if (!containingClassType.isStable(context.evaluator, resolveUClass = { containingClass })) {
         context.report(
           ISSUE,
           method,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Types.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Types.kt
@@ -10,3 +10,15 @@ val PsiClass.isFunctionalInterface: Boolean
       qualifiedName == "kotlin.Function" ||
       qualifiedName?.startsWith("kotlin.jvm.functions.") == true
   }
+
+val PsiClass.allSupertypes: Sequence<PsiClass>
+  get() {
+    return sequenceOf(this) +
+      superTypes
+        .asSequence()
+        .distinct()
+        .mapNotNull { it.resolve() }
+        .filterNot { it.qualifiedName == "java.lang.Object" }
+        .flatMap { resolved -> sequenceOf(resolved).plus(resolved.allSupertypes) }
+        .distinct()
+  }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
@@ -97,6 +97,7 @@ class PreviewNamingDetectorTest : BaseComposeLintTest() {
 
         @Preview
         @Preview
+        @Repeatable
         annotation class BananaPreview
         @BananaPreview
         @BananaPreview

--- a/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
@@ -106,6 +106,7 @@ class PreviewNamingDetectorTest : BaseComposeLintTest() {
         .trimIndent()
     lint()
       .files(*commonStubs, kotlin(code))
+      .allowDuplicates()
       .run()
       .expect(
         """

--- a/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
@@ -114,7 +114,7 @@ class PreviewNamingDetectorTest : BaseComposeLintTest() {
           See https://slackhq.github.io/compose-lints/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @Preview
           ^
-          src/BananaPreview.kt:6: Error: Preview annotations with 2 preview annotations should end with the Previews suffix.
+          src/BananaPreview.kt:7: Error: Preview annotations with 2 preview annotations should end with the Previews suffix.
           See https://slackhq.github.io/compose-lints/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @BananaPreview
           ^

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
@@ -75,6 +75,16 @@ class UnstableReceiverDetectorTest : BaseComposeLintTest() {
         fun (() -> Unit).OtherContent() {}
         @Composable
         fun Function<String>.OtherContent() {}
+
+        // Supertypes
+        @Stable
+        interface Presenter<T> {
+          @Composable fun present(): T
+        }
+
+        class HomePresenter : Presenter<String> {
+          @Composable override fun present(): String { return "hi" }
+        }
       """
         .trimIndent()
     lint().files(*commonStubs, kotlin(code)).run().expectClean()
@@ -100,6 +110,15 @@ class UnstableReceiverDetectorTest : BaseComposeLintTest() {
 
         @get:Composable
         val Example.OtherContentProperty get() {}
+
+        // Supertypes
+        interface Presenter<T> {
+          @Composable fun present(): T
+        }
+
+        class HomePresenter : Presenter<String> {
+          @Composable override fun present(): String { return "hi" }
+        }
       """
         .trimIndent()
     lint()
@@ -119,7 +138,13 @@ class UnstableReceiverDetectorTest : BaseComposeLintTest() {
           src/ExampleInterface.kt:15: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible. See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
           val Example.OtherContentProperty get() {}
               ~~~~~~~
-          0 errors, 4 warnings
+          src/ExampleInterface.kt:19: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible. See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+            @Composable fun present(): T
+                            ~~~~~~~
+          src/ExampleInterface.kt:23: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible. See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+            @Composable override fun present(): String { return "hi" }
+                                     ~~~~~~~
+          0 errors, 6 warnings
         """
           .trimIndent()
       )


### PR DESCRIPTION
Stability annotations are inherited

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->