### PR TITLE
Use name of parameter if text is not available

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -32,9 +32,7 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
       )
 
     fun getText(uParameter: UParameter): String {
-      val psiElement = uParameter.sourcePsi
-        ?: return "${uParameter.name}: ${uParameter.type.presentableText}"
-      return psiElement.text
+      return uParameter.sourcePsi?.text ?: "${uParameter.name}: ${uParameter.type.presentableText}"
     }
 
     private fun createErrorMessage(currentOrder: String, properOrder: String): String =

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -25,11 +25,21 @@ import slack.lint.compose.util.sourceImplementation
 class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
   companion object {
-    fun createErrorMessage(currentOrder: List<UParameter>, properOrder: List<UParameter>): String =
+    fun createErrorMessage(
+      currentOrder: List<UParameter>,
+      properOrder: List<UParameter>
+    ): String =
       createErrorMessage(
-        currentOrder.joinToString { it.text },
-        properOrder.joinToString { it.text },
+        currentOrder.joinToString { getText(it) },
+        properOrder.joinToString { getText(it) },
       )
+
+    fun getText(uParameter: UParameter): String =
+      try {
+        uParameter.text
+      } catch (exception: Exception) {
+        uParameter.name
+      }
 
     private fun createErrorMessage(currentOrder: String, properOrder: String): String =
       """
@@ -99,7 +109,7 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
         fix()
           .replace()
           .range(errorLocation)
-          .with(properOrder.joinToString(prefix = "(", postfix = ")") { it.text })
+          .with(properOrder.joinToString(prefix = "(", postfix = ")") { getText(it) })
           .reformat(true)
           .build(),
       )
@@ -117,7 +127,9 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
     // Fall back to thorough check in case of aliases
     val resolved =
-      evaluator.getTypeClass(valueParameters.lastOrNull()?.toUElementOfType<UParameter>()?.type)
+      evaluator.getTypeClass(
+        valueParameters.lastOrNull()?.toUElementOfType<UParameter>()?.type
+      )
         ?: return false
     return resolved.isFunctionalInterface
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -31,12 +31,11 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
         properOrder.joinToString { getText(it) },
       )
 
-    fun getText(uParameter: UParameter): String =
-      try {
-        uParameter.text
-      } catch (exception: Exception) {
-        "${uParameter.name}: ${uParameter.type.presentableText}"
-      }
+    fun getText(uParameter: UParameter): String {
+      val psiElement = uParameter.sourcePsi
+        ?: return "${uParameter.name}: ${uParameter.type.presentableText}"
+      return psiElement.text
+    }
 
     private fun createErrorMessage(currentOrder: String, properOrder: String): String =
       """

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UParameter
-import org.jetbrains.uast.toUElement
 import org.jetbrains.uast.toUElementOfType
 import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isFunctionalInterface
@@ -34,7 +33,6 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
     fun getText(uParameter: UParameter): String =
       try {
-        uParameter.toUElement()
         uParameter.text
       } catch (exception: Exception) {
         "${uParameter.name}: ${uParameter.type.presentableText}"

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UParameter
+import org.jetbrains.uast.toUElement
 import org.jetbrains.uast.toUElementOfType
 import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isFunctionalInterface
@@ -25,10 +26,7 @@ import slack.lint.compose.util.sourceImplementation
 class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
   companion object {
-    fun createErrorMessage(
-      currentOrder: List<UParameter>,
-      properOrder: List<UParameter>
-    ): String =
+    fun createErrorMessage(currentOrder: List<UParameter>, properOrder: List<UParameter>): String =
       createErrorMessage(
         currentOrder.joinToString { getText(it) },
         properOrder.joinToString { getText(it) },
@@ -36,9 +34,10 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
     fun getText(uParameter: UParameter): String =
       try {
+        uParameter.toUElement()
         uParameter.text
       } catch (exception: Exception) {
-        uParameter.name
+        "${uParameter.name}: ${uParameter.type.presentableText}"
       }
 
     private fun createErrorMessage(currentOrder: String, properOrder: String): String =
@@ -127,9 +126,7 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
     // Fall back to thorough check in case of aliases
     val resolved =
-      evaluator.getTypeClass(
-        valueParameters.lastOrNull()?.toUElementOfType<UParameter>()?.type
-      )
+      evaluator.getTypeClass(valueParameters.lastOrNull()?.toUElementOfType<UParameter>()?.type)
         ?: return false
     return resolved.isFunctionalInterface
   }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
@@ -101,7 +101,7 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
           fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:20: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
-          Current params are: [text: String, modifier: Modifier, lambda: Function0<Unit>] but should be [modifier: Modifier, text: String, lambda: Function0<Unit>].
+          Current params are: [text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit] but should be [modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit].
           See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
           inline fun <reified T> MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) : T { }
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -131,10 +131,10 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
           @@ -17 +17
           - fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
           + fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
-          Fix for src/test.kt line 20: Replace with (modifier: Modifier, text: String, lambda: Function0<Unit>):
+          Fix for src/test.kt line 20: Replace with (modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit):
           @@ -20 +20
           - inline fun <reified T> MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) : T { }
-          + inline fun <reified T> MyComposable(modifier: Modifier, text: String, lambda: Function0<Unit>) : T { }
+          + inline fun <reified T> MyComposable(modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit) : T { }
         """
           .trimIndent()
       )

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
@@ -35,7 +35,7 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
 
         @Composable
         fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
-      
+
         @Composable
         inline fun <reified T> MyComposable(modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit) : T { }
       """
@@ -65,7 +65,7 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
 
         @Composable
         fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
-    
+
         @Composable
         inline fun <reified T> MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) : T { }
       """
@@ -101,7 +101,7 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
           fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:20: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
-          Current params are: [text, modifier, lambda] but should be [modifier, text, lambda].
+          Current params are: [text: String, modifier: Modifier, lambda: Function0<Unit>] but should be [modifier: Modifier, text: String, lambda: Function0<Unit>].
           See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
           inline fun <reified T> MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) : T { }
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -131,11 +131,11 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
           @@ -17 +17
           - fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
           + fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
-          Fix for src/test.kt line 20: Replace with (modifier, text, lambda):
+          Fix for src/test.kt line 20: Replace with (modifier: Modifier, text: String, lambda: Function0<Unit>):
           @@ -20 +20
           - inline fun <reified T> MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) : T { }
-          + inline fun <reified T> MyComposable(modifier, text, lambda) : T { }
-          """
+          + inline fun <reified T> MyComposable(modifier: Modifier, text: String, lambda: Function0<Unit>) : T { }
+        """
           .trimIndent()
       )
   }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
@@ -35,6 +35,9 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
 
         @Composable
         fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
+      
+        @Composable
+        inline fun <reified T> MyComposable(modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit) : T { }
       """
         .trimIndent()
     lint().files(*commonStubs, kotlin(code)).run().expectClean()
@@ -62,6 +65,9 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
 
         @Composable
         fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
+    
+        @Composable
+        inline fun <reified T> MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) : T { }
       """
         .trimIndent()
     lint()
@@ -94,7 +100,12 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
           See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
           fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          5 errors, 0 warnings
+          src/test.kt:20: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          Current params are: [text, modifier, lambda] but should be [modifier, text, lambda].
+          See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
+          inline fun <reified T> MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) : T { }
+                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          6 errors, 0 warnings
         """
           .trimIndent()
       )
@@ -120,6 +131,10 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
           @@ -17 +17
           - fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
           + fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
+          Fix for src/test.kt line 20: Replace with (modifier, text, lambda):
+          @@ -20 +20
+          - inline fun <reified T> MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) : T { }
+          + inline fun <reified T> MyComposable(modifier, text, lambda) : T { }
           """
           .trimIndent()
       )


### PR DESCRIPTION
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->

Fixes https://github.com/slackhq/compose-lints/issues/273

For standard compose functions, `method.uastParameters` returns parameter with delegated to KtUltraLightParameterForSource. KtUltraLightParameterForSource has proper text function to return.

When method is generic with reified, delegated uast becomes UastKotlinPsiParameter and getText of UastKotlinPsiParameter returns null.

Those are from my investigation.

In this PR I suggest checking name of the parameter if text fails. If you know better way/ correct way to get text when function is reified, I can update the solution.

Example reified usage is `androidx.lifecycle.viewmodel.compose.viewModel`. We had a wrapper with wrong parameter order to hit this issue.