### PR TITLE
Fix broken reference link in Modifier rules section

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -251,7 +251,7 @@ Modifiers are the beating heart of Compose UI. They encapsulate the idea of comp
 
 They are especially important for your public components, as they allow callers to customize the component to their wishes.
 
-More info: [Always provide a Modifier parameter](https://chris.banes.dev/posts/always-provide-a-modifier/)
+More info: [Always provide a Modifier parameter](https://chrisbanes.me/posts/always-provide-a-modifier/)
 
 Related rule: [`ComposeModifierMissing`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ModifierMissingDetector.kt)
 


### PR DESCRIPTION
Fix for "Expose Modifier Param" rule docs reference a broken link #303

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->