### PR TITLE
Remove broken link to Modifier.composed{ }

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -314,7 +314,7 @@ Using `@Composable` builder functions for modifiers is not recommended, as they 
 
 Composed modifiers may be created outside of composition, shared across elements, and declared as top-level constants, making them more flexible than modifiers that can only be created via a `@Composable` function call, and easier to avoid accidentally sharing state across elements.
 
-More info: [Modifier extensions](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#extension-functions), [Composed modifiers in Jetpack Compose by Jorge Castillo](https://jorgecastillo.dev/composed-modifiers-in-jetpack-compose), [Custom Modifiers](https://developer.android.com/jetpack/compose/custom-modifiers), and [Composed modifiers in API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#composed-modifiers)
+More info: [Modifier extensions](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#extension-functions), [Composed modifiers in Jetpack Compose by Jorge Castillo](https://jorgecastillo.dev/composed-modifiers-in-jetpack-compose) and [Custom Modifiers](https://developer.android.com/jetpack/compose/custom-modifiers)
 
 Related rule: [`ComposeComposableModifier`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposableDetector.kt)
 


### PR DESCRIPTION
`Modifier.composed {}` section has been removed from the Compose API guidelines in https://github.com/androidx/androidx/commit/ed53c47eb77241ceaa8bea40fb7ac6bbf81ef9d2.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->