### PR TITLE
Fix issue id for `ComposeUnstableReceiver` in rules.md.

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -73,7 +73,7 @@ _restartable_ or _skippable_. This _includes_ the containing class or receiver, 
 
 More info: [Compose API Stability](https://developer.android.com/jetpack/compose/performance/stability)
 
-Related rule: [`UnstableReceiverDetector`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt)
+Related rule: [`ComposeUnstableReceiver`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt)
 
 ### Do not emit content and return a result
 


### PR DESCRIPTION
Update `rules.md` to change the related rule name to be the issue id `ComposeUnstableReceiver` instead of `UnstableReceiverDetector`.
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->