### PR TITLE
Implement SlotReusedDetector

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
@@ -37,6 +37,7 @@ class ComposeLintsIssueRegistry : IssueRegistry() {
       PreviewNamingDetector.ISSUE,
       PreviewPublicDetector.ISSUE,
       RememberMissingDetector.ISSUE,
+      SlotReusedDetector.ISSUE,
       UnstableCollectionsDetector.ISSUE,
       ViewModelForwardingDetector.ISSUE,
       ViewModelInjectionDetector.ISSUE,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
@@ -21,16 +21,9 @@ import slack.lint.compose.util.findChildrenByClass
 import slack.lint.compose.util.slotParameters
 import slack.lint.compose.util.sourceImplementation
 
-class SlotReusedDetector
-@JvmOverloads
-constructor(
-  private val contentEmitterOption: ContentEmitterLintOption =
-    ContentEmitterLintOption(CONTENT_EMITTER_OPTION)
-) : ComposableFunctionDetector(contentEmitterOption), SourceCodeScanner {
+class SlotReusedDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
   companion object {
-
-    val CONTENT_EMITTER_OPTION = ContentEmitterLintOption.newOption()
 
     val ISSUE =
       Issue.create(
@@ -47,11 +40,9 @@ constructor(
           severity = Severity.ERROR,
           implementation = sourceImplementation<SlotReusedDetector>(),
         )
-        .setOptions(listOf(CONTENT_EMITTER_OPTION))
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
-    if (!function.emitsContent(contentEmitterOption.value)) return
     val composableBlockExpression = function.bodyBlockExpression ?: return
     val slotParameters = method.slotParameters(context.evaluator)
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
@@ -39,8 +39,7 @@ constructor(
           explanation =
             """
             Slots should be invoked in at most once place to meet lifecycle expectations. \
-            Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. \
-            Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. \
+            Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. \
             See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information.
           """,
           category = Category.CORRECTNESS,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
@@ -1,0 +1,103 @@
+// Copyright (C) 2024 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.isAncestor
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.emitsContent
+import slack.lint.compose.util.findChildrenByClass
+import slack.lint.compose.util.slotParameters
+import slack.lint.compose.util.sourceImplementation
+
+class SlotReusedDetector
+@JvmOverloads
+constructor(
+  private val contentEmitterOption: ContentEmitterLintOption =
+    ContentEmitterLintOption(CONTENT_EMITTER_OPTION)
+) : ComposableFunctionDetector(contentEmitterOption), SourceCodeScanner {
+
+  companion object {
+
+    val CONTENT_EMITTER_OPTION = ContentEmitterLintOption.newOption()
+
+    val ISSUE =
+      Issue.create(
+          id = "SlotReused",
+          briefDescription = "Slots should be invoked in at most one place",
+          explanation =
+            """
+            Slots should be invoked in at most once place to meet lifecycle expectations. \
+            Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. \
+            Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. \
+            See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information.
+          """,
+          category = Category.CORRECTNESS,
+          priority = Priorities.NORMAL,
+          severity = Severity.ERROR,
+          implementation = sourceImplementation<SlotReusedDetector>(),
+        )
+        .setOptions(listOf(CONTENT_EMITTER_OPTION))
+  }
+
+  override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
+    if (!function.emitsContent(contentEmitterOption.value)) return
+    val composableBlockExpression = function.bodyBlockExpression ?: return
+    val slotParameters = method.slotParameters(context.evaluator)
+
+    val callExpressions = composableBlockExpression.findChildrenByClass<KtCallExpression>().toList()
+    val innerLambdas = composableBlockExpression.findChildrenByClass<KtLambdaExpression>().toList()
+
+    slotParameters.forEach { slotParameter ->
+      // Find lambdas that shadow this parameter name, to make sure that they aren't shadowing
+      // the references we are looking through
+      val lambdasWithMatchingParameterName =
+        innerLambdas.filter { innerLambda ->
+          // Otherwise look to see if any of the parameters on the inner lambda have the
+          // same name
+          innerLambda.valueParameters
+            // Ignore parameters with a destructuring declaration instead of a named
+            // parameter
+            .filter { it.destructuringDeclaration == null }
+            .any { it.name == slotParameter.name }
+        }
+
+      // Count all direct calls of the slot parameter.
+      // NOTE: this misses cases where the slot parameter is passed as an argument to another
+      // method, which may or may not invoke the slot parameter, but there are cases where that is
+      // valid, like using the slot parameter as the key for a remember
+      val slotParameterCallCount =
+        callExpressions
+          .filter { reference ->
+            // The parameter is referenced if there is at least one reference that isn't shadowed by
+            // an inner lambda
+            lambdasWithMatchingParameterName.none { it.isAncestor(reference) }
+          }
+          .count { reference ->
+            (reference.calleeExpression as? KtNameReferenceExpression)?.getReferencedName() ==
+              slotParameter.name
+          }
+
+      // Report an issue if the slot parameter was invoked in multiple places
+      if (slotParameterCallCount > 1) {
+        context.report(
+          ISSUE,
+          slotParameter as UElement,
+          context.getLocation(slotParameter as UElement),
+          ISSUE.getExplanation(TextFormat.TEXT),
+        )
+      }
+    }
+  }
+}

--- a/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.psi.psiUtil.isAncestor
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UMethod
 import slack.lint.compose.util.Priorities
-import slack.lint.compose.util.emitsContent
 import slack.lint.compose.util.findChildrenByClass
 import slack.lint.compose.util.slotParameters
 import slack.lint.compose.util.sourceImplementation
@@ -27,19 +26,19 @@ class SlotReusedDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
     val ISSUE =
       Issue.create(
-          id = "SlotReused",
-          briefDescription = "Slots should be invoked in at most one place",
-          explanation =
-            """
+        id = "SlotReused",
+        briefDescription = "Slots should be invoked in at most one place",
+        explanation =
+          """
             Slots should be invoked in at most once place to meet lifecycle expectations. \
             Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. \
             See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information.
           """,
-          category = Category.CORRECTNESS,
-          priority = Priorities.NORMAL,
-          severity = Severity.ERROR,
-          implementation = sourceImplementation<SlotReusedDetector>(),
-        )
+        category = Category.CORRECTNESS,
+        priority = Priorities.NORMAL,
+        severity = Severity.ERROR,
+        implementation = sourceImplementation<SlotReusedDetector>(),
+      )
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
@@ -168,6 +168,10 @@ fun UParameter.isModifier(evaluator: JavaEvaluator): Boolean {
   return ModifierQualifiedNames.any { evaluator.typeMatches(type, it) }
 }
 
+fun UParameter.isSlotParameter(evaluator: JavaEvaluator): Boolean =
+  typeReference?.type?.hasAnnotation("androidx.compose.runtime.Composable") == true &&
+    evaluator.getTypeClass(this.type).let { it != null && it.isFunctionalInterface }
+
 val KtCallableDeclaration.isModifierReceiver: Boolean
   get() = ModifierNames.contains(receiverTypeReference?.text)
 
@@ -181,6 +185,9 @@ fun UMethod.modifierParameter(evaluator: JavaEvaluator): UParameter? {
   val modifiers = uastParameters.filter { it.isModifier(evaluator) }
   return modifiers.firstOrNull { it.name == "modifier" } ?: modifiers.firstOrNull()
 }
+
+fun UMethod.slotParameters(evaluator: JavaEvaluator): List<UParameter> =
+  uastParameters.filter { it.isSlotParameter(evaluator) }
 
 val KtProperty.declaresCompositionLocal: Boolean
   get() {

--- a/compose-lint-checks/src/test/java/slack/lint/compose/BaseComposeLintTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/BaseComposeLintTest.kt
@@ -57,6 +57,8 @@ abstract class BaseComposeLintTest : LintDetectorTest() {
           ): State<T> = TODO()
 
           inline fun <T> remember(crossinline calculation: () -> T): T = TODO()
+
+          fun movableContentOf(content: @Composable () -> Unit): @Composable () -> Unit = TODO()
       """
           .trimIndent()
       ),

--- a/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
@@ -52,10 +52,10 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:7: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+          src/test.kt:7: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
             slot: @Composable () -> Unit,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:18: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+          src/test.kt:18: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
             slot: @Composable () -> Unit,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           2 errors, 0 warnings
@@ -94,7 +94,7 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
             slot: @Composable () -> Unit,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           1 errors, 0 warnings
@@ -135,7 +135,7 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
             slot: @Composable () -> Unit,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           1 errors, 0 warnings
@@ -177,10 +177,10 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
             slot1: @Composable () -> Unit,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:9: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+          src/test.kt:9: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
             slot2: @Composable () -> Unit,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           2 errors, 0 warnings

--- a/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
@@ -5,6 +5,7 @@ package slack.lint.compose
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
+import org.junit.Assume.assumeFalse
 import org.junit.Test
 
 class SlotReusedDetectorTest : BaseComposeLintTest() {
@@ -15,6 +16,8 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
 
   @Test
   fun `errors when the slot parameter of a Composable is used more than once at the same time`() {
+    // Currently fails on K2 UAST, related to https://issuetracker.google.com/issues/361986680
+    assumeFalse(TestBuildConfig.USE_K2_UAST)
     @Language("kotlin")
     val code =
       """
@@ -66,6 +69,8 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
 
   @Test
   fun `errors when the slot parameter of a Composable is used more than once in different branches`() {
+    // Currently fails on K2 UAST, related to https://issuetracker.google.com/issues/361986680
+    assumeFalse(TestBuildConfig.USE_K2_UAST)
     @Language("kotlin")
     val code =
       """
@@ -105,6 +110,8 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
 
   @Test
   fun `errors when slot parameter is used in different movableContentOfs`() {
+    // Currently fails on K2 UAST, related to https://issuetracker.google.com/issues/361986680
+    assumeFalse(TestBuildConfig.USE_K2_UAST)
     @Language("kotlin")
     val code =
       """
@@ -146,6 +153,8 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
 
   @Test
   fun `errors when multiple slot parameters of a Composable are used more than once in different branches`() {
+    // Currently fails on K2 UAST, related to https://issuetracker.google.com/issues/361986680
+    assumeFalse(TestBuildConfig.USE_K2_UAST)
     @Language("kotlin")
     val code =
       """
@@ -191,6 +200,8 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
 
   @Test
   fun `passes when the slot parameter is shadowed`() {
+    // Currently fails on K2 UAST, related to https://issuetracker.google.com/issues/361986680
+    assumeFalse(TestBuildConfig.USE_K2_UAST)
     @Language("kotlin")
     val code =
       """
@@ -264,6 +275,8 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
 
   @Test
   fun `passes when using slot parameter in only one branch`() {
+    // Currently fails on K2 UAST, related to https://issuetracker.google.com/issues/361986680
+    assumeFalse(TestBuildConfig.USE_K2_UAST)
     @Language("kotlin")
     val code =
       """

--- a/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
@@ -1,0 +1,293 @@
+// Copyright (C) 2024 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class SlotReusedDetectorTest : BaseComposeLintTest() {
+
+  override fun getDetector(): Detector = SlotReusedDetector()
+
+  override fun getIssues(): List<Issue> = listOf(SlotReusedDetector.ISSUE)
+
+  @Test
+  fun `errors when the slot parameter of a Composable is used more than once at the same time`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          slot: @Composable () -> Unit,
+        ) {
+          Row(modifier) {
+            slot()
+            slot()
+          }
+        }
+
+        @Composable
+        fun SomethingElse(
+          modifier: Modifier = Modifier,
+          slot: @Composable () -> Unit,
+        ) {
+          Column(modifier) {
+            slot()
+            Box {
+              slot()
+            }
+          }
+        }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/test.kt:7: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+            slot: @Composable () -> Unit,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          src/test.kt:18: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+            slot: @Composable () -> Unit,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors when the slot parameter of a Composable is used more than once in different branches`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot: @Composable () -> Unit,
+        ) {
+          Box(modifier) {
+            if (flag) {
+              slot()
+            } else {
+              slot()
+            }
+          }
+        }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+            slot: @Composable () -> Unit,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors when slot parameter is used in different movableContentOfs`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot: @Composable () -> Unit,
+        ) {
+          val movableSlot1 = remember(slot) { movableContentOf { slot() } }
+          val movableSlot2 = remember(slot) { movableContentOf { slot() } }
+          Box(modifier) {
+            if (flag) {
+              movableSlot1()
+            } else {
+              movableSlot2()
+            }
+          }
+        }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+            slot: @Composable () -> Unit,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors when multiple slot parameters of a Composable are used more than once in different branches`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot1: @Composable () -> Unit,
+          slot2: @Composable () -> Unit,
+        ) {
+          Box(modifier) {
+            if (flag) {
+              slot1()
+              slot2()
+            } else {
+              slot1()
+              slot2()
+            }
+          }
+        }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+            slot1: @Composable () -> Unit,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          src/test.kt:9: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked multiple times in the same composition, as callers don't expect the slot's contents to be duplicated in multiple places. Slots should also not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+            slot2: @Composable () -> Unit,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `passes when the slot parameter is shadowed`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot: @Composable () -> Unit,
+        ) {
+          Box(modifier) {
+            slot()
+            SomethingElse { slot ->
+              slot()
+            }
+          }
+        }
+
+        @Composable
+        fun SomethingElse(
+          modifier: Modifier = Modifier,
+          content: @Composable (@Composable () -> Unit) -> Unit,
+        ) {
+          Box(modifier) {
+            content {
+              Spacer()
+            }
+          }
+        }
+
+
+      """
+        .trimIndent()
+
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `passes when using movableContentOf for the slot parameter`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.runtime.movableContentOf
+        import androidx.compose.runtime.remember
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot: @Composable () -> Unit,
+        ) {
+          val movableSlot = remember(slot) { movableContentOf(slot) }
+          Box(modifier) {
+            if (flag) {
+              movableSlot()
+            } else {
+              movableSlot()
+            }
+          }
+        }
+
+      """
+        .trimIndent()
+
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `passes when using slot parameter in only one branch`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot: @Composable () -> Unit,
+        ) {
+          Box(modifier) {
+            if (flag) {
+              slot()
+            } else {
+              Spacer()
+            }
+          }
+        }
+
+      """
+        .trimIndent()
+
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -154,9 +154,10 @@ Slot parameters provide a convenient and idiomatic way to accept arbitrary conte
 
 Callers of a component that takes a slot parameter have natural expectations about the lifecycle of
 that slot.
-Specifically, the slot should either be composed (invoked) exactly once, or not invoked at all.
-Furthermore, if the slot is continuously composed, even if there are visual or structure changes
-inside the component, callers expect the internal state of the slot to be preserved.
+Specifically, the slot should either be composed (invoked) in exactly one place, or not invoked at
+all.
+Even if there are visual or structure changes inside the component, callers expect the internal
+state of the slot to be preserved.
 
 Components should either use custom layouts to meet this expectation or `movableContentOf`.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -148,6 +148,22 @@ Related rule: [`ComposeMultipleContentEmitters`](https://github.com/slackhq/comp
     </issue>
     ```
 
+### Do not invoke slots in more than once place
+
+Slot parameters provide a convenient and idiomatic way to accept arbitrary content for a component.
+
+Callers of a component that takes a slot parameter have natural expectations about the lifecycle of
+that slot.
+Specifically, the slot should either be composed (invoked) exactly once, or not invoked at all.
+Furthermore, if the slot is continuously composed, even if there are visual or structure changes
+inside the component, callers expect the internal state of the slot to be preserved.
+
+Components should either use custom layouts to meet this expectation or `movableContentOf`.
+
+More information: [Lifecycle expectations for slot parameters](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-component-api-guidelines.md#lifecycle-expectations-for-slot-parameters)
+
+Related rule: [`SlotReused`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt)
+
 ### Naming multipreview annotations properly
 
 Multipreview annotations should be named by using `Previews` as suffix (or `Preview` if just one). These annotations have to be explicitly named to make sure that they are clearly identifiable as a `@Preview` alternative on its usages.
@@ -376,4 +392,3 @@ Material 3 (M3) reached stable in October 2022. In apps that have migrated to M3
 - Guidance: https://developer.android.com/jetpack/compose/themes/material3
 - Reply (primary sample app): https://github.com/android/compose-samples/tree/main/Reply
 - More samples: https://github.com/android/compose-samples
-


### PR DESCRIPTION
Implements SlotReusedDetector, for a new lint rule "SlotReused".

This lint rule counts for how many places that a slot parameter for a component is invoked, and creates an error if it is invoked in more than one place in the source code.

This helps enforce https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-component-api-guidelines.md#lifecycle-expectations-for-slot-parameters

Fixes #367

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->
