### PR TITLE
Allow test-only previews to be public + better recurse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 
 - **Fix**: Don't report duplicate errors about multiple content emitters.
 - **Enhancement**: Report the function name for readability in `ComposeContentEmitterReturningValues`.
+- **Enhancement**: Check for inherited `@Preview` annotations up to four levels.
+- **Enhancement**: Allow `@VisibleForTestin`/`@TestOnly`-annotated preview composables to be public.
 
 1.3.1
 -----

--- a/compose-lint-checks/src/main/java/slack/lint/compose/PreviewPublicDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/PreviewPublicDetector.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 import org.jetbrains.uast.UMethod
 import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isPreview
+import slack.lint.compose.util.isVisibleForTesting
 import slack.lint.compose.util.sourceImplementation
 
 class PreviewPublicDetector : ComposableFunctionDetector(), SourceCodeScanner {
@@ -44,6 +45,8 @@ class PreviewPublicDetector : ComposableFunctionDetector(), SourceCodeScanner {
     if (!method.isPreview) return
     // We only care about public methods
     if (!function.isPublic) return
+    // If it's used for tests, allow it
+    if (method.isVisibleForTesting) return
 
     // If we got here, it's a public method in a @Preview composable with a @PreviewParameter
     // parameter

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Previews.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Previews.kt
@@ -10,16 +10,29 @@ private const val COMPOSE_PREVIEW = "androidx.compose.ui.tooling.preview.Preview
 private const val COMPOSE_DESKTOP_PREVIEW = "androidx.compose.desktop.ui.tooling.preview.Preview"
 
 val PREVIEW_ANNOTATIONS = setOf(COMPOSE_PREVIEW, COMPOSE_DESKTOP_PREVIEW)
+val TEST_ANNOTATIONS =
+  setOf(
+    "org.jetbrains.annotations.TestOnly",
+    "com.google.common.annotations.VisibleForTesting",
+    "androidx.annotation.VisibleForTesting",
+  )
 
 val UAnnotated.isPreview: Boolean
   get() =
     uAnnotations.any {
-      // Is it itself a preview annotation?
       it.resolve()?.let { cls ->
         cls.qualifiedName in PREVIEW_ANNOTATIONS ||
+          // Is the annotation itself a preview-annotated annotation?
           cls.hasAnnotation(COMPOSE_PREVIEW) ||
           cls.hasAnnotation(COMPOSE_DESKTOP_PREVIEW)
       } ?: false
+    }
+
+val UAnnotated.isVisibleForTesting: Boolean
+  get() =
+    uAnnotations.any {
+      // Is it itself a preview annotation?
+      it.resolve()?.let { cls -> cls.qualifiedName in TEST_ANNOTATIONS } ?: false
     }
 
 val UParameter.isPreviewParameter: Boolean

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierMissingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierMissingDetectorTest.kt
@@ -372,6 +372,36 @@ class ModifierMissingDetectorTest : BaseComposeLintTest() {
     lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
 
+  // https://github.com/slackhq/compose-lints/issues/377
+  @Test
+  fun `deeply nested previews can still be detected and allowed`() {
+    @Language("kotlin")
+    val code =
+      """
+          import androidx.compose.runtime.Composable
+          import androidx.compose.ui.tooling.preview.Preview
+          import androidx.compose.ui.Modifier
+
+          @Preview
+          annotation class DeviceWidthPreviews
+
+          @DeviceWidthPreviews
+          annotation class ThemePreviews
+
+          @ThemePreviews
+          annotation class ComponentPreviews
+
+          @ComponentPreviews
+          @Composable
+          fun Something() {
+            Text("Hi")
+          }
+      """
+        .trimIndent()
+
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
   @Test
   fun `non content emitting root composables are ignored`() {
     @Language("kotlin")

--- a/compose-lint-checks/src/test/java/slack/lint/compose/PreviewPublicDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/PreviewPublicDetectorTest.kt
@@ -207,7 +207,6 @@ class PreviewPublicDetectorTest : BaseComposeLintTest() {
 
           annotation class VisibleForTesting
         """
-            .trimIndent()
         ),
         *commonStubs,
         kotlin(code),

--- a/compose-lint-checks/src/test/java/slack/lint/compose/PreviewPublicDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/PreviewPublicDetectorTest.kt
@@ -181,4 +181,38 @@ class PreviewPublicDetectorTest : BaseComposeLintTest() {
         .trimIndent()
     lint().files(stubs, *commonStubs, kotlin(code)).run().expectClean()
   }
+
+  // https://github.com/slackhq/compose-lints/issues/379
+  @Test
+  fun `test-only public previews are ok`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.annotation.VisibleForTesting
+
+        @VisibleForTesting
+        @Preview
+        @Composable
+        fun MyComposable() {}
+      """
+        .trimIndent()
+    lint()
+      .files(
+        stubs,
+        kotlin(
+          """
+          package androidx.annotation
+
+          annotation class VisibleForTesting
+        """
+            .trimIndent()
+        ),
+        *commonStubs,
+        kotlin(code),
+      )
+      .run()
+      .expectClean()
+  }
 }


### PR DESCRIPTION
Resolves #379, resolves #377

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->