### PR TITLE
Improve SlotReusedDetector

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/SlotReusedDetector.kt
@@ -8,13 +8,13 @@ import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.TextFormat
+import com.intellij.psi.PsiManager
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtLambdaExpression
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
-import org.jetbrains.kotlin.psi.psiUtil.isAncestor
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.toUElement
+import org.jetbrains.uast.tryResolve
 import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.findChildrenByClass
 import slack.lint.compose.util.slotParameters
@@ -46,37 +46,21 @@ class SlotReusedDetector : ComposableFunctionDetector(), SourceCodeScanner {
     val slotParameters = method.slotParameters(context.evaluator)
 
     val callExpressions = composableBlockExpression.findChildrenByClass<KtCallExpression>().toList()
-    val innerLambdas = composableBlockExpression.findChildrenByClass<KtLambdaExpression>().toList()
+
+    val psiManager = PsiManager.getInstance(context.project.ideaProject)
 
     slotParameters.forEach { slotParameter ->
-      // Find lambdas that shadow this parameter name, to make sure that they aren't shadowing
-      // the references we are looking through
-      val lambdasWithMatchingParameterName =
-        innerLambdas.filter { innerLambda ->
-          // Otherwise look to see if any of the parameters on the inner lambda have the
-          // same name
-          innerLambda.valueParameters
-            // Ignore parameters with a destructuring declaration instead of a named
-            // parameter
-            .filter { it.destructuringDeclaration == null }
-            .any { it.name == slotParameter.name }
-        }
-
       // Count all direct calls of the slot parameter.
       // NOTE: this misses cases where the slot parameter is passed as an argument to another
       // method, which may or may not invoke the slot parameter, but there are cases where that is
       // valid, like using the slot parameter as the key for a remember
       val slotParameterCallCount =
-        callExpressions
-          .filter { reference ->
-            // The parameter is referenced if there is at least one reference that isn't shadowed by
-            // an inner lambda
-            lambdasWithMatchingParameterName.none { it.isAncestor(reference) }
-          }
-          .count { reference ->
-            (reference.calleeExpression as? KtNameReferenceExpression)?.getReferencedName() ==
-              slotParameter.name
-          }
+        callExpressions.count { callExpression ->
+          psiManager.areElementsEquivalent(
+            callExpression.calleeExpression?.toUElement()?.tryResolve(),
+            slotParameter,
+          )
+        }
 
       // Report an issue if the slot parameter was invoked in multiple places
       if (slotParameterCallCount > 1) {

--- a/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
@@ -290,4 +290,60 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
 
     lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
+
+  @Test
+  fun `passes when using same name is used as a different function`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          first: @Composable () -> Unit,
+        ) {
+          Box(modifier) {
+            first()
+            listOf("1").first { it == "2" }
+          }
+        }
+
+      """
+        .trimIndent()
+
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `passes when using same slot name is used with a different receiver`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        class Section(
+          // other stuff
+          val content: @Composable () -> Unit,
+        )
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          section: Section? = null,
+          content: @Composable () -> Unit,
+        ) {
+          Box(modifier) {
+            content()
+            section?.content()
+          }
+        }
+
+      """
+        .trimIndent()
+
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
 }


### PR DESCRIPTION
By resolving the call references to check against the parameter, this allows removing the custom shadowing logic, and also fixes cases where a different reference with the same name as the slot was causing false positives.

Fixes #424 and fixes #434

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->
