### PR TITLE
Add slot parameter passing detection to SlotReusedDetector

### DIFF
--- a/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
@@ -104,6 +104,98 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun `errors when the slot parameter passed to other composables in more than one place`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot: @Composable () -> Unit,
+        ) {
+          Box(modifier) {
+            if (flag) {
+              AnotherThing(slot = slot)
+            } else {
+              AnotherThing(slot = slot)
+            }
+          }
+        }
+
+        @Composable
+        fun AnotherThing(
+          modifier: Modifier = Modifier,
+          slot: @Composable () -> Unit,
+        )
+
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+            slot: @Composable () -> Unit,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors when the slot parameter is passed to another composables and called directly`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot: @Composable () -> Unit,
+        ) {
+          Box(modifier) {
+            if (flag) {
+              AnotherThing(slot = slot)
+            } else {
+              slot()
+            }
+          }
+        }
+
+        @Composable
+        fun AnotherThing(
+          modifier: Modifier = Modifier,
+          slot: @Composable () -> Unit,
+        )
+
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+          src/test.kt:8: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+            slot: @Composable () -> Unit,
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `errors when slot parameter is used in different movableContentOfs`() {
     @Language("kotlin")
     val code =
@@ -340,6 +432,43 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
             section?.content()
           }
         }
+
+      """
+        .trimIndent()
+
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `passes when passing slot parameter to different composable transformations`() {
+    @Language("kotlin")
+    val code =
+      """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+
+        @Composable
+        fun Something(
+          modifier: Modifier = Modifier,
+          flag: Boolean,
+          slot: @Composable () -> Unit,
+        ) {
+          val transformedSlot = if (flag) {
+            transformationA(slot)
+          } else {
+            transformationB(slot)
+          }
+
+          Box(modifier) {
+            transformedSlot()
+          }
+        }
+
+        @Composable
+        fun transformationA(slot: @Composable () -> Unit): @Composable () -> Unit = slot
+
+        @Composable
+        fun transformationB(slot: @Composable () -> Unit): @Composable () -> Unit = slot
 
       """
         .trimIndent()


### PR DESCRIPTION
Another common way that a slot can be used in multiple places that wasn't caught in the existing rule implementation was when the slot is directly passed as a parameter to the slot of another composable function. By counting those instances in addition to directly invoking the slot parameter, this catches more cases where the lifecycle expectation of slots is violated.

This fixes #404.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->