### PR TITLE
Add lint rule to prevent using Locale.getDefault() in Composable functions

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
@@ -43,5 +43,6 @@ class ComposeLintsIssueRegistry : IssueRegistry() {
       ViewModelInjectionDetector.ISSUE,
       ModifierComposedDetector.ISSUE,
       UnstableReceiverDetector.ISSUE,
+      LocaleGetDefaultDetector.ISSUE
     )
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
@@ -43,6 +43,6 @@ class ComposeLintsIssueRegistry : IssueRegistry() {
       ViewModelInjectionDetector.ISSUE,
       ModifierComposedDetector.ISSUE,
       UnstableReceiverDetector.ISSUE,
-      LocaleGetDefaultDetector.ISSUE
+      LocaleGetDefaultDetector.ISSUE,
     )
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/LocaleGetDefaultDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/LocaleGetDefaultDetector.kt
@@ -1,0 +1,53 @@
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.uast.UMethod
+import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.findChildrenByClass
+import slack.lint.compose.util.sourceImplementation
+
+class LocaleGetDefaultDetector : ComposableFunctionDetector(), SourceCodeScanner {
+
+    companion object {
+        val ISSUE =
+            Issue.create(
+                id = "LocaleGetDefaultDetector",
+                briefDescription = "Avoid using Locale.getDefault() in Composable functions",
+                explanation =
+                """
+                    Using `Locale.getDefault()` in a @Composable function does not trigger recomposition when the locale changes (e.g., during a Configuration change). \  
+                    Instead, use `LocalConfiguration.current.locales`, which correctly updates UI and works better for previews and tests.  
+                """,
+                category = Category.CORRECTNESS,
+                priority = Priorities.NORMAL,
+                severity = Severity.ERROR,
+                implementation = sourceImplementation<LocaleGetDefaultDetector>(),
+            )
+    }
+
+    override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
+
+        function
+            .findChildrenByClass<KtProperty>()
+            .filter {
+                val property = it.initializer?.text ?: return@filter false
+                property.contains("Locale.getDefault()")
+            }.forEach { property ->
+                context.report(
+                    ISSUE,
+                    property,
+                    context.getLocation(property),
+                    """
+                        Don't use `Locale.getDefault()` in a @Composable function.
+                        Use `LocalConfiguration.current.locales` instead to properly handle locale changes."
+                     """
+                )
+            }
+    }
+}

--- a/compose-lint-checks/src/main/java/slack/lint/compose/LocaleGetDefaultDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/LocaleGetDefaultDetector.kt
@@ -9,6 +9,7 @@ import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.ULambdaExpression
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.getParentOfType
 import slack.lint.compose.util.Priorities
@@ -42,8 +43,9 @@ class LocaleGetDefaultDetector : ComposableFunctionDetector(), SourceCodeScanner
 
     if (!context.evaluator.isMemberInClass(method, JAVA_UTIL_LOCALE)) return
 
-    val parentFunction = node.getParentOfType(UMethod::class.java) ?: return
+    if (node.isInLambdaBlock()) return
 
+    val parentFunction = node.getParentOfType(UMethod::class.java) ?: return
     if (parentFunction.isComposable) {
       context.report(
         ISSUE,
@@ -55,5 +57,9 @@ class LocaleGetDefaultDetector : ComposableFunctionDetector(), SourceCodeScanner
                      """,
       )
     }
+  }
+
+  private fun UCallExpression.isInLambdaBlock(): Boolean {
+    return this.getParentOfType(ULambdaExpression::class.java) != null
   }
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/LocaleGetDefaultDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/LocaleGetDefaultDetector.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2025 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
 import com.android.tools.lint.detector.api.Category
@@ -15,47 +17,43 @@ import slack.lint.compose.util.sourceImplementation
 
 class LocaleGetDefaultDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
-    companion object {
-        const val JAVA_UTIL_LOCALE ="java.util.Locale"
+  companion object {
+    const val JAVA_UTIL_LOCALE = "java.util.Locale"
 
-        val ISSUE =
-            Issue.create(
-                id = "LocaleGetDefaultDetector",
-                briefDescription = "Avoid using `Locale.getDefault()` in Composable functions",
-                explanation =
-                """
-                    Using `Locale.getDefault()` in a @Composable function does not trigger recomposition when the locale changes (e.g., during a Configuration change). \  
-                    Instead, use `LocalConfiguration.current.locales`, which correctly updates UI and works better for previews and tests.  
+    val ISSUE =
+      Issue.create(
+        id = "LocaleGetDefaultDetector",
+        briefDescription = "Avoid using `Locale.getDefault()` in Composable functions",
+        explanation =
+          """
+                    Using `Locale.getDefault()` in a @Composable function does not trigger recomposition when the locale changes (e.g., during a Configuration change). \
+                    Instead, use `LocalConfiguration.current.locales`, which correctly updates UI and works better for previews and tests.
                 """,
-                category = Category.CORRECTNESS,
-                priority = Priorities.NORMAL,
-                severity = Severity.ERROR,
-                implementation = sourceImplementation<LocaleGetDefaultDetector>(),
-            )
-    }
+        category = Category.CORRECTNESS,
+        priority = Priorities.NORMAL,
+        severity = Severity.ERROR,
+        implementation = sourceImplementation<LocaleGetDefaultDetector>(),
+      )
+  }
 
-    override fun getApplicableMethodNames(): List<String> = listOf("getDefault")
+  override fun getApplicableMethodNames(): List<String> = listOf("getDefault")
 
+  override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
 
-    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+    if (!context.evaluator.isMemberInClass(method, JAVA_UTIL_LOCALE)) return
 
-        if (!context.evaluator.isMemberInClass(method, JAVA_UTIL_LOCALE)) return
+    val parentFunction = node.getParentOfType(UMethod::class.java) ?: return
 
-        val parentFunction = node.getParentOfType(UMethod::class.java) ?: return
-
-        if (parentFunction.isComposable) {
-            context.report(
-                ISSUE,
-                node,
-                context.getLocation(node),
-                """
+    if (parentFunction.isComposable) {
+      context.report(
+        ISSUE,
+        node,
+        context.getLocation(node),
+        """
                         Don't use `Locale.getDefault()` in a @Composable function.
                         Use `LocalConfiguration.current.locales` instead to properly handle locale changes."
-                     """
-            )
-        }
-
+                     """,
+      )
     }
-
-
+  }
 }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/LocaleGetDefaultDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/LocaleGetDefaultDetectorTest.kt
@@ -31,11 +31,11 @@ class LocaleGetDefaultDetectorTest : BaseComposeLintTest() {
             .run()
             .expect(
                 """
-                    src/test.kt:6: Error: Don't use Locale.getDefault() in a @Composable function.
-                    Use LocalConfiguration.current.locales instead to properly handle locale changes." [LocaleGetDefaultDetector]
-                        val locale = Locale.getDefault()
-                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                    1 errors, 0 warnings
+                src/test.kt:6: Error: Don't use Locale.getDefault() in a @Composable function.
+                Use LocalConfiguration.current.locales instead to properly handle locale changes." [LocaleGetDefaultDetector]
+                    val locale = Locale.getDefault()
+                                 ~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
                 """.trimIndent()
             )
     }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/LocaleGetDefaultDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/LocaleGetDefaultDetectorTest.kt
@@ -19,14 +19,20 @@ class LocaleGetDefaultDetectorTest : BaseComposeLintTest() {
     @Language("kotlin")
     val code =
       """
-                import java.util.Locale
-                import androidx.compose.runtime.Composable
+        import java.util.Locale
+        import androidx.compose.runtime.Composable
 
-                @Composable
-                fun Something() {
-                    val locale = Locale.getDefault()
-                }
-            """
+        @Composable
+        fun Something() {
+
+            val locale = Locale.getDefault()
+
+           SideEffect {
+                Locale.getDefault()
+           }
+
+        }
+    """
         .trimIndent()
     lint()
       .skipTestModes(TestMode.WHITESPACE, TestMode.IMPORT_ALIAS)
@@ -34,12 +40,12 @@ class LocaleGetDefaultDetectorTest : BaseComposeLintTest() {
       .run()
       .expect(
         """
-                src/test.kt:6: Error: Don't use Locale.getDefault() in a @Composable function.
-                Use LocalConfiguration.current.locales instead to properly handle locale changes." [LocaleGetDefaultDetector]
-                    val locale = Locale.getDefault()
-                                 ~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
-                """
+            src/test.kt:7: Error: Don't use Locale.getDefault() in a @Composable function.
+            Use LocalConfiguration.current.locales instead to properly handle locale changes." [LocaleGetDefaultDetector]
+                val locale = Locale.getDefault()
+                             ~~~~~~~~~~~~~~~~~~~
+            1 errors, 0 warnings
+        """
           .trimIndent()
       )
   }

--- a/compose-lint-checks/src/test/java/slack/lint/compose/LocaleGetDefaultDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/LocaleGetDefaultDetectorTest.kt
@@ -1,0 +1,43 @@
+package slack.lint.compose
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class LocaleGetDefaultDetectorTest : BaseComposeLintTest() {
+
+    override fun getDetector(): Detector = LocaleGetDefaultDetector()
+
+    override fun getIssues(): List<Issue> = listOf(LocaleGetDefaultDetector.ISSUE)
+
+    @Test
+    fun `errors when composable uses Locale_getDefault()`() {
+        @Language("kotlin")
+        val code =
+            """
+                import java.util.Locale
+                import androidx.compose.runtime.Composable
+        
+                @Composable
+                fun Something() {
+                    val locale = Locale.getDefault()
+                }
+            """.trimIndent()
+        lint()
+            .skipTestModes(TestMode.WHITESPACE, TestMode.IMPORT_ALIAS)
+            .files(*commonStubs, kotlin(code))
+            .run()
+            .expect(
+                """
+                    src/test.kt:6: Error: Don't use Locale.getDefault() in a @Composable function.
+                    Use LocalConfiguration.current.locales instead to properly handle locale changes." [LocaleGetDefaultDetector]
+                        val locale = Locale.getDefault()
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    1 errors, 0 warnings
+                """.trimIndent()
+            )
+    }
+}
+

--- a/compose-lint-checks/src/test/java/slack/lint/compose/LocaleGetDefaultDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/LocaleGetDefaultDetectorTest.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2025 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
 import com.android.tools.lint.checks.infrastructure.TestMode
@@ -8,36 +10,37 @@ import org.junit.Test
 
 class LocaleGetDefaultDetectorTest : BaseComposeLintTest() {
 
-    override fun getDetector(): Detector = LocaleGetDefaultDetector()
+  override fun getDetector(): Detector = LocaleGetDefaultDetector()
 
-    override fun getIssues(): List<Issue> = listOf(LocaleGetDefaultDetector.ISSUE)
+  override fun getIssues(): List<Issue> = listOf(LocaleGetDefaultDetector.ISSUE)
 
-    @Test
-    fun `errors when composable uses Locale_getDefault()`() {
-        @Language("kotlin")
-        val code =
-            """
+  @Test
+  fun `errors when composable uses Locale_getDefault()`() {
+    @Language("kotlin")
+    val code =
+      """
                 import java.util.Locale
                 import androidx.compose.runtime.Composable
-        
+
                 @Composable
                 fun Something() {
                     val locale = Locale.getDefault()
                 }
-            """.trimIndent()
-        lint()
-            .skipTestModes(TestMode.WHITESPACE, TestMode.IMPORT_ALIAS)
-            .files(*commonStubs, kotlin(code))
-            .run()
-            .expect(
-                """
+            """
+        .trimIndent()
+    lint()
+      .skipTestModes(TestMode.WHITESPACE, TestMode.IMPORT_ALIAS)
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
                 src/test.kt:6: Error: Don't use Locale.getDefault() in a @Composable function.
                 Use LocalConfiguration.current.locales instead to properly handle locale changes." [LocaleGetDefaultDetector]
                     val locale = Locale.getDefault()
                                  ~~~~~~~~~~~~~~~~~~~
                 1 errors, 0 warnings
-                """.trimIndent()
-            )
-    }
+                """
+          .trimIndent()
+      )
+  }
 }
-

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -260,6 +260,12 @@ Related rule: [`ComposePreviewPublic`](https://github.com/slackhq/compose-lints/
 > **Note**: If you are using Detekt, this may conflict with Detekt's [UnusedPrivateMember rule](https://detekt.dev/docs/rules/style/#unusedprivatemember).
 Be sure to set Detekt's [ignoreAnnotated configuration](https://detekt.dev/docs/introduction/compose/#unusedprivatemember) to ['Preview'] for compatibility with this rule.
 
+### `Locale.getDefault()` should not be used in in composable functions
+
+Using `Locale.getDefault()` in a composable function does not trigger recomposition when the locale changes (e.g., during a Configuration change). Instead, use `LocalConfiguration.current.locales`, which correctly updates UI and works better for previews and tests.
+
+Related rule: [`ComposePreviewNaming`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/LocaleGetDefaultDetector.kt)
+
 ## Modifiers
 
 ### When should I expose modifier parameters?


### PR DESCRIPTION
try to resolve https://github.com/slackhq/compose-lints/issues/373 !

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->