### PR TITLE
Allow missing ANDROID_HOME when running tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,12 +9,6 @@ The primary project is `slack-lint`.
 
 Kotlin should be used for more idiomatic use with lint APIs.
 
-## Setup
-
-Be sure your devel environment has `ANDROID_HOME` defined or you'll have trouble running tests
-that require the Android SDK. If you've added it and still seeing the error about not having it
-defined while running tests, try closing and re-opening Android Studio.
-
 ## Lint Documentation
 
 [The Android Lint API Guide](https://googlesamples.github.io/android-custom-lint-rules/book.html) provides an excellent overview of lint's purpose, how it works, and how to author custom checks.

--- a/compose-lint-checks/src/test/java/slack/lint/compose/BaseComposeLintTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/BaseComposeLintTest.kt
@@ -112,7 +112,7 @@ abstract class BaseComposeLintTest : LintDetectorTest() {
 
   override fun lint(): TestLintTask {
     val lintTask = super.lint()
-    lintTask.allowCompilationErrors(false)
+    lintTask.allowCompilationErrors(false).allowMissingSdk(true)
 
     skipTestModes?.let { testModesToSkip -> lintTask.skipTestModes(*testModesToSkip) }
     return lintTask


### PR DESCRIPTION
This PR removes the need for ANDROID_HOME to be set when running tests.

All tests still pass with this change, and it will help our team (Android
SystemUI) to reuse these nice Compose lints :-)

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->
