### PR TITLE
Update KSP to 2.3.7 and JDK toolchain to 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: '23'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: '23'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: '23'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
 import com.android.build.gradle.internal.lint.LintModelWriterTask
 import com.diffplug.gradle.spotless.KotlinExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.google.devtools.ksp.gradle.KspTask
+import com.google.devtools.ksp.gradle.KspAATask
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.dokka.gradle.DokkaExtension
@@ -158,8 +158,10 @@ subprojects {
   // TODO workaround for https://issuetracker.google.com/issues/269089135
   pluginManager.withPlugin("com.google.devtools.ksp") {
     tasks.withType<AndroidLintAnalysisTask>().configureEach {
-      mustRunAfter(tasks.withType<KspTask>())
+      mustRunAfter(tasks.withType<KspAATask>())
     }
-    tasks.withType<LintModelWriterTask>().configureEach { mustRunAfter(tasks.withType<KspTask>()) }
+    tasks.withType<LintModelWriterTask>().configureEach {
+      mustRunAfter(tasks.withType<KspAATask>())
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,6 @@ android.experimental.lint.missingBaselineIsEmptyBaseline=true
 
 android.lint.useK2Uast=true
 
-# https://github.com/google/ksp/issues/1839
-ksp.useKSP2=false
-
 # Dokka flags
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.3.21"
 ktfmt = "0.56"
-jdk = "21"
+jdk = "23"
 jvmTarget = "17"
 lint = "32.2.0"
 lint-latest = "32.2.0"
@@ -11,7 +11,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.23.8" }
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 lint = { id = "com.android.lint", version = "9.2.0" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version = "2.2.0-2.0.2" }
+ksp = { id = "com.google.devtools.ksp", version = "2.3.7" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
 spotless = { id = "com.diffplug.spotless", version = "8.4.0" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ pluginManagement {
   }
 }
 
+// Apply the foojay-resolver plugin to allow automatic download of JDKs
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0" }
+
 dependencyResolutionManagement {
   versionCatalogs {
     if (System.getenv("DEP_OVERRIDES") == "true") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,9 +11,6 @@ pluginManagement {
   }
 }
 
-// Apply the foojay-resolver plugin to allow automatic download of JDKs
-plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0" }
-
 dependencyResolutionManagement {
   versionCatalogs {
     if (System.getenv("DEP_OVERRIDES") == "true") {


### PR DESCRIPTION
## Summary

Update KSP from 2.2.0 to 2.3.7 for Kotlin 2.3.21 compatibility and bump the JDK toolchain target from 21 to 23.

## Description

The Kotlin 2.3.21 upgrade. KSP 2.3.x also removed KSP1 entirely and renamed `KspTask` to `KspAATask`.

**Changes:**
- Upgrade KSP plugin from `2.2.0-2.0.2` to `2.3.7` (new standalone versioning scheme, no longer prefixed with Kotlin version)
- Update `KspTask` references to `KspAATask` in the lint task ordering workaround
- Remove `ksp.useKSP2=false` from `gradle.properties` since KSP1 no longer exists in 2.3.x
- Bump JDK toolchain from 21 to 23 