### PR TITLE
chore: update Renovate GitHub Action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v40.2.6
+        uses: renovatebot/github-action@v46.1.13
         with:
           configurationFile: .github/workflows/renovate.json
           token: ${{ secrets.SLACKHQ_MBR_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update the self-hosted Renovate workflow from `renovatebot/github-action@v40.2.6` to `v46.1.13`
- keep the existing schedule, `configurationFile`, and Slack-owned token wiring unchanged

## Verification
- static diff check: this PR only changes the Renovate GitHub Action version in `.github/workflows/renovate.yml`
- project tests were not run because this is a workflow-only maintenance update
