### PR TITLE
Fix value class stability detection + disable stability detection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
-- **Fix**: Fix `ComposeUnstableReceiver` false positives on Kotlin `value class` receivers and on composable members of `value class` types. Value classes are now treated as stable when their underlying property type is stable.
+- **Behavior change**: The stability checks (`ComposeUnstableReceiver`, `ComposeMutableParameters`, `ComposeUnstableCollections`) are now **disabled by default** as they are significantly less important in the era of Compose strong skipping. Re-enable them via the new `stability-checks` option in `lint.xml`. See https://slackhq.github.io/compose-lints/rules/#stability.
+- **Fix**: Fix `ComposeUnstableReceiver` false positives on Kotlin `value class` receivers and on composable members of `value class` types. Value classes are now treated as stable when their underlying property type is stable, including for compiled cross-module classes (via a metadata-aware evaluator).
 - **Enhancement**: Improve `ModifierReused` data flow analysis.
 - Build against lint `32.2.1`.
 - Target Kotlin 2.2 (matches lint 32.*).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 **Unreleased**
 --------------
 
+- **Fix**: Fix `ComposeUnstableReceiver` false positives on Kotlin `value class` receivers and on composable members of `value class` types. Value classes are now treated as stable when their underlying property type is stable.
 - **Enhancement**: Improve `ModifierReused` data flow analysis.
 - Build against lint `32.2.1`.
 - Target Kotlin 2.2 (matches lint 32.*).

--- a/compose-lint-checks/build.gradle.kts
+++ b/compose-lint-checks/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright (C) 2023 Salesforce, Inc.
 // SPDX-License-Identifier: Apache-2.0
+import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
+import com.android.build.gradle.internal.lint.LintModelWriterTask
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -9,6 +12,7 @@ plugins {
   alias(libs.plugins.lint)
   alias(libs.plugins.ksp)
   alias(libs.plugins.mavenPublish)
+  alias(libs.plugins.shadow)
 }
 
 lint {
@@ -28,11 +32,23 @@ tasks.test {
   maxParallelForks = Runtime.getRuntime().availableProcessors() * 2
 }
 
+// Dependencies in this configuration are shaded (relocated) into the final artifact. This is needed
+// for libraries like kotlin-metadata that aren't available on lint's runtime classpath.
+val shade: Configuration = configurations.maybeCreate("compileShaded")
+
+configurations.getByName("compileOnly").extendsFrom(shade)
+
 dependencies {
   compileOnly(libs.lint.api)
   compileOnly(libs.lint.checks)
   ksp(libs.autoService.ksp)
   implementation(libs.autoService.annotations)
+  shade(libs.kotlin.metadata) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
+
+  // Dupe the dep because the shaded version is compileOnly in the eyes of the gradle configurations
+  testImplementation(libs.kotlin.metadata) {
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+  }
   testImplementation(libs.bundles.lintTest)
   testImplementation(libs.junit)
 }
@@ -48,3 +64,24 @@ tasks.withType<KotlinCompile>().configureEach {
     languageVersion.set(kgpKotlinVersion)
   }
 }
+
+val shadowJar =
+  tasks.shadowJar.apply {
+    configure {
+      archiveClassifier.set("")
+      configurations = listOf(shade)
+      relocate("kotlin.metadata", "slack.lint.compose.shaded.kotlin.metadata")
+      transformers.add(ServiceFileTransformer())
+    }
+  }
+
+artifacts {
+  runtimeOnly(shadowJar)
+  archives(shadowJar)
+}
+
+// shadowJar uses an empty classifier so it replaces the default jar that lint's analysis tasks
+// consume. Order those tasks after shadowJar so Gradle's task-dependency validation is satisfied.
+tasks.withType<AndroidLintAnalysisTask>().configureEach { mustRunAfter(shadowJar) }
+
+tasks.withType<LintModelWriterTask>().configureEach { mustRunAfter(shadowJar) }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
@@ -21,20 +21,20 @@ class MutableParametersDetector : ComposableFunctionDetector(), SourceCodeScanne
   companion object {
     val ISSUE =
       Issue.create(
-        id = "ComposeMutableParameters",
-        briefDescription = "Mutable objects in Compose will break state",
-        explanation =
-          """
+          id = "ComposeMutableParameters",
+          briefDescription = "Mutable objects in Compose will break state",
+          explanation =
+            """
               Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.\
               Mutable objects that are not observable, such as `ArrayList<T>` or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.\
               See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information.
             """,
-        category = Category.PRODUCTIVITY,
-        priority = Priorities.NORMAL,
-        severity = Severity.ERROR,
-        implementation = sourceImplementation<MutableParametersDetector>(),
-      )
-      .setOptions(listOf(STABILITY_CHECKS_OPTION))
+          category = Category.PRODUCTIVITY,
+          priority = Priorities.NORMAL,
+          severity = Severity.ERROR,
+          implementation = sourceImplementation<MutableParametersDetector>(),
+        )
+        .setOptions(listOf(STABILITY_CHECKS_OPTION))
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {

--- a/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt
@@ -12,8 +12,10 @@ import com.android.tools.lint.detector.api.TextFormat
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.uast.UMethod
 import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.STABILITY_CHECKS_OPTION
 import slack.lint.compose.util.isTypeMutable
 import slack.lint.compose.util.sourceImplementation
+import slack.lint.compose.util.stabilityChecksEnabled
 
 class MutableParametersDetector : ComposableFunctionDetector(), SourceCodeScanner {
   companion object {
@@ -32,9 +34,12 @@ class MutableParametersDetector : ComposableFunctionDetector(), SourceCodeScanne
         severity = Severity.ERROR,
         implementation = sourceImplementation<MutableParametersDetector>(),
       )
+      .setOptions(listOf(STABILITY_CHECKS_OPTION))
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
+    if (!context.stabilityChecksEnabled()) return
+
     method.uastParameters
       .filter { it.isTypeMutable(context.evaluator) }
       .forEach { parameter ->

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableCollectionsDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableCollectionsDetector.kt
@@ -13,8 +13,10 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.uast.UMethod
 import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.STABILITY_CHECKS_OPTION
 import slack.lint.compose.util.isTypeUnstableCollection
 import slack.lint.compose.util.sourceImplementation
+import slack.lint.compose.util.stabilityChecksEnabled
 
 class UnstableCollectionsDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
@@ -43,9 +45,12 @@ class UnstableCollectionsDetector : ComposableFunctionDetector(), SourceCodeScan
         severity = Severity.WARNING,
         implementation = sourceImplementation<UnstableCollectionsDetector>(),
       )
+      .setOptions(listOf(STABILITY_CHECKS_OPTION))
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
+    if (!context.stabilityChecksEnabled()) return
+
     for (param in method.uastParameters.filter { it.isTypeUnstableCollection(context.evaluator) }) {
       val variableName = param.name
       val type = (param.sourcePsi as? KtParameter)?.typeReference?.text ?: "List/Set/Map"

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableCollectionsDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableCollectionsDetector.kt
@@ -37,15 +37,15 @@ class UnstableCollectionsDetector : ComposableFunctionDetector(), SourceCodeScan
 
     val ISSUE =
       Issue.create(
-        id = "ComposeUnstableCollections",
-        briefDescription = "Immutable collections should ideally be used in Composables",
-        explanation = "This is replaced when reported",
-        category = Category.PRODUCTIVITY,
-        priority = Priorities.NORMAL,
-        severity = Severity.WARNING,
-        implementation = sourceImplementation<UnstableCollectionsDetector>(),
-      )
-      .setOptions(listOf(STABILITY_CHECKS_OPTION))
+          id = "ComposeUnstableCollections",
+          briefDescription = "Immutable collections should ideally be used in Composables",
+          explanation = "This is replaced when reported",
+          category = Category.PRODUCTIVITY,
+          priority = Priorities.NORMAL,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<UnstableCollectionsDetector>(),
+        )
+        .setOptions(listOf(STABILITY_CHECKS_OPTION))
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
@@ -17,10 +17,13 @@ import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UTypeReferenceExpression
 import org.jetbrains.uast.getContainingUClass
 import org.jetbrains.uast.toUElementOfType
+import slack.lint.compose.util.MetadataJavaEvaluator
 import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.STABILITY_CHECKS_OPTION
 import slack.lint.compose.util.isStable
 import slack.lint.compose.util.returnsUnitOrVoid
 import slack.lint.compose.util.sourceImplementation
+import slack.lint.compose.util.stabilityChecksEnabled
 
 class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner {
   companion object {
@@ -39,6 +42,7 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
         severity = Severity.WARNING,
         implementation = sourceImplementation<UnstableReceiverDetector>(),
       )
+      .setOptions(listOf(STABILITY_CHECKS_OPTION))
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {
@@ -46,9 +50,15 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod) {
+    if (!context.stabilityChecksEnabled()) return
+
+    // Use a metadata-aware evaluator so value-class receivers/containers are understood even when
+    // they come from other modules compiled without source (checkDependencies=false).
+    val evaluator = MetadataJavaEvaluator(context.file.name, context.evaluator)
+
     // Only Unit-returning functions can be skippable. Non-skippable functions will always be
     // recomposed regardless of the receiver type, so there's nothing actionable to report.
-    if (!method.returnsUnitOrVoid(context.evaluator)) return
+    if (!method.returnsUnitOrVoid(evaluator)) return
 
     val receiverTypeReference: KtTypeReference? =
       when (val source = method.sourcePsi) {
@@ -64,7 +74,7 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
       val receiverType: PsiType? =
         method.uastParameters.firstOrNull()?.type
           ?: receiverTypeReference.toUElementOfType<UTypeReferenceExpression>()?.type
-      if (receiverType?.isStable(context.evaluator) == false) {
+      if (receiverType?.isStable(evaluator) == false) {
         context.report(
           ISSUE,
           receiverTypeReference,
@@ -85,9 +95,9 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
           // passed as a receiver) and file facades, whose synthetic *Kt class is the "container"
           // of top-level/extension declarations rather than an actual receiver type.
           ?.takeIf { it.sourcePsi is KtClass }
-          ?.let(context.evaluator::getClassType) ?: return
+          ?.let(evaluator::getClassType) ?: return
 
-      if (!containingClassType.isStable(context.evaluator, resolveUClass = { containingClass })) {
+      if (!containingClassType.isStable(evaluator, resolveUClass = { containingClass })) {
         context.report(
           ISSUE,
           method,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
@@ -9,13 +9,14 @@ import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.TextFormat
 import com.intellij.psi.PsiType
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.psi.KtTypeReference
-import org.jetbrains.kotlin.psi.psiUtil.isTopLevelKtOrJavaMember
 import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UTypeReferenceExpression
 import org.jetbrains.uast.getContainingUClass
+import org.jetbrains.uast.toUElementOfType
 import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isStable
 import slack.lint.compose.util.returnsUnitOrVoid
@@ -45,55 +46,54 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod) {
-    lateinit var nodeToReport: KtTypeReference
-    val receiverParam = method.uastParameters.firstOrNull()
-    val receiverType: PsiType? =
+    // Only Unit-returning functions can be skippable. Non-skippable functions will always be
+    // recomposed regardless of the receiver type, so there's nothing actionable to report.
+    if (!method.returnsUnitOrVoid(context.evaluator)) return
+
+    val receiverTypeReference: KtTypeReference? =
       when (val source = method.sourcePsi) {
-        is KtFunction -> {
-          source.receiverTypeReference?.let {
-            nodeToReport = it
-            // Receiver is the first uastParameter
-            receiverParam?.type
-          }
-        }
-        is KtPropertyAccessor -> {
-          source.property.receiverTypeReference?.let {
-            nodeToReport = it
-            // Receiver is the first uastParameter
-            receiverParam?.type
-          }
-        }
+        is KtFunction -> source.receiverTypeReference
+        is KtPropertyAccessor -> source.property.receiverTypeReference
         else -> null
       }
 
-    // Only non-Unit returning functions can be skippable.
-    // Non-skippable functions will always be recomposed regardless of the receiver type.
-    if (method.returnsUnitOrVoid(context.evaluator)) {
+    if (receiverTypeReference != null) {
+      // This is an extension. Its receiver is the value that gets recomposed, so check its
+      // stability. The receiver is normally the first uastParameter, but for value-class receivers
+      // K2 UAST doesn't surface it as a parameter, so fall back to resolving the type reference.
+      val receiverType: PsiType? =
+        method.uastParameters.firstOrNull()?.type
+          ?: receiverTypeReference.toUElementOfType<UTypeReferenceExpression>()?.type
       if (receiverType?.isStable(context.evaluator) == false) {
         context.report(
           ISSUE,
-          nodeToReport,
-          context.getLocation(nodeToReport),
+          receiverTypeReference,
+          context.getLocation(receiverTypeReference),
           ISSUE.getExplanation(TextFormat.TEXT),
         )
-      } else if (!method.isTopLevelKtOrJavaMember() && !method.isStatic) {
-        // We check both the receiver and the containing class, as classes could have
-        // extension functions in their declarations too.
-        val containingClass = method.getContainingUClass()
-        val containingClassType =
-          containingClass
-            // If the containing class is an object, it will never be passed as a receiver arg
-            ?.takeUnless { it.sourcePsi is KtObjectDeclaration }
-            ?.let(context.evaluator::getClassType) ?: return
+        return
+      }
+    }
 
-        if (!containingClassType.isStable(context.evaluator, resolveUClass = { containingClass })) {
-          context.report(
-            ISSUE,
-            method,
-            context.getNameLocation(method),
-            ISSUE.getExplanation(TextFormat.TEXT),
-          )
-        }
+    // For instance (and member-extension) functions the containing class is also passed as a
+    // receiver, so check its stability too.
+    if (!method.isStatic) {
+      val containingClass = method.getContainingUClass()
+      val containingClassType =
+        containingClass
+          // Only a real class declaration is passed as a receiver. This excludes objects (never
+          // passed as a receiver) and file facades, whose synthetic *Kt class is the "container"
+          // of top-level/extension declarations rather than an actual receiver type.
+          ?.takeIf { it.sourcePsi is KtClass }
+          ?.let(context.evaluator::getClassType) ?: return
+
+      if (!containingClassType.isStable(context.evaluator, resolveUClass = { containingClass })) {
+        context.report(
+          ISSUE,
+          method,
+          context.getNameLocation(method),
+          ISSUE.getExplanation(TextFormat.TEXT),
+        )
       }
     }
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/UnstableReceiverDetector.kt
@@ -29,20 +29,20 @@ class UnstableReceiverDetector : ComposableFunctionDetector(), SourceCodeScanner
   companion object {
     val ISSUE =
       Issue.create(
-        id = "ComposeUnstableReceiver",
-        briefDescription = "Unstable receivers will always be recomposed",
-        explanation =
-          """
+          id = "ComposeUnstableReceiver",
+          briefDescription = "Unstable receivers will always be recomposed",
+          explanation =
+            """
               Instance composable functions on non-stable classes will always be recomposed. \
               If possible, make the receiver type stable or refactor this function if that isn't possible. \
               See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information.
             """,
-        category = Category.PRODUCTIVITY,
-        priority = Priorities.NORMAL,
-        severity = Severity.WARNING,
-        implementation = sourceImplementation<UnstableReceiverDetector>(),
-      )
-      .setOptions(listOf(STABILITY_CHECKS_OPTION))
+          category = Category.PRODUCTIVITY,
+          priority = Priorities.NORMAL,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<UnstableReceiverDetector>(),
+        )
+        .setOptions(listOf(STABILITY_CHECKS_OPTION))
   }
 
   override fun visitComposable(context: JavaContext, method: UMethod, function: KtFunction) {

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/MetadataJavaEvaluator.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/MetadataJavaEvaluator.kt
@@ -1,5 +1,4 @@
 // Copyright (C) 2024 Salesforce, Inc.
-// Copyright (C) 2023 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose.util
 
@@ -251,7 +250,9 @@ class MetadataJavaEvaluator(private val file: String, private val delegate: Java
       }
     return when (parsedMetadata) {
       is KotlinClassMetadata.Class -> {
-        parsedMetadata.kmClass.also { metadataLog("Loaded KmClass for $classNameHint from file $file") }
+        parsedMetadata.kmClass.also {
+          metadataLog("Loaded KmClass for $classNameHint from file $file")
+        }
       }
       else -> {
         metadataLog(

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/MetadataJavaEvaluator.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/MetadataJavaEvaluator.kt
@@ -1,0 +1,335 @@
+// Copyright (C) 2024 Salesforce, Inc.
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose.util
+
+import com.android.tools.lint.client.api.JavaEvaluator
+import com.android.tools.lint.model.LintModelDependencies
+import com.intellij.lang.jvm.JvmClassKind
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiArrayInitializerMemberValue
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiCompiledElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.PsiType
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.jvm.optionals.getOrNull
+import kotlin.metadata.ClassKind
+import kotlin.metadata.KmClass
+import kotlin.metadata.Modality
+import kotlin.metadata.isData
+import kotlin.metadata.isValue
+import kotlin.metadata.jvm.JvmMetadataVersion
+import kotlin.metadata.jvm.KotlinClassMetadata
+import kotlin.metadata.jvm.Metadata as MetadataWithNullableArgs
+import kotlin.metadata.kind
+import kotlin.metadata.modality
+import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.uast.UAnnotated
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.findContaining
+import org.jetbrains.uast.toUElementOfType
+
+/**
+ * A delegating [JavaEvaluator] that implements more comprehensive checks for Kotlin classes via
+ * metadata annotations.
+ *
+ * This is important because, when `checkDependencies` is set to false, Lint detectors cannot see
+ * Kotlin language features in externally-compiled elements. This means that constructs like `data
+ * classes` or `value classes` are not visible. Using kotlin-metadata, we can parse the [Metadata]
+ * annotations on the containing classes and read these language features from them.
+ *
+ * This is necessary due to https://issuetracker.google.com/issues/283654244.
+ *
+ * Ported from
+ * [slack-lints](https://github.com/slackhq/slack-lints/blob/main/slack-lint-checks/src/main/java/slack/lint/util/MetadataJavaEvaluator.kt).
+ */
+class MetadataJavaEvaluator(private val file: String, private val delegate: JavaEvaluator) :
+  JavaEvaluator() {
+
+  private companion object {
+    // Not an exhaustive list, but at least the ones we look at currently
+    private val KOTLIN_METADATA_TOKENS =
+      mapOf(
+        KtTokens.DATA_KEYWORD to TokenData { it.isData },
+        KtTokens.SEALED_KEYWORD to
+          TokenData(applicableClassKinds = setOf(JvmClassKind.CLASS, JvmClassKind.INTERFACE)) {
+            it.modality == Modality.SEALED
+          },
+        KtTokens.OBJECT_KEYWORD to TokenData { it.kind == ClassKind.OBJECT },
+        KtTokens.COMPANION_KEYWORD to TokenData { it.kind == ClassKind.COMPANION_OBJECT },
+        KtTokens.VALUE_KEYWORD to TokenData { it.isValue },
+      )
+  }
+
+  private data class TokenData(
+    val applicableClassKinds: Set<JvmClassKind> = setOf(JvmClassKind.CLASS),
+    val isApplicable: (KmClass) -> Boolean,
+  )
+
+  /** Flag to disable as needed. */
+  private val checkMetadata =
+    System.getProperty("slack.lint.compose.checkMetadata", "true").toBoolean()
+  private val cachedClasses = ConcurrentHashMap<String, Optional<KmClass>>()
+
+  // region Delegating functions
+  override val dependencies: LintModelDependencies?
+    get() = delegate.dependencies
+
+  override fun extendsClass(cls: PsiClass?, className: String, strict: Boolean): Boolean =
+    delegate.extendsClass(cls, className, strict)
+
+  @Suppress("DEPRECATION")
+  @Deprecated(
+    "Use getAnnotation returning a UAnnotation instead",
+    replaceWith = ReplaceWith("getAnnotation(listOwner, *annotationNames)"),
+  )
+  override fun findAnnotation(
+    listOwner: PsiModifierListOwner?,
+    vararg annotationNames: String,
+  ): PsiAnnotation? = delegate.findAnnotation(listOwner, *annotationNames)
+
+  @Suppress("DEPRECATION")
+  @Deprecated(
+    "Use getAnnotationInHierarchy returning a UAnnotation instead",
+    replaceWith = ReplaceWith("getAnnotationInHierarchy(listOwner, *annotationNames)"),
+  )
+  override fun findAnnotationInHierarchy(
+    listOwner: PsiModifierListOwner,
+    vararg annotationNames: String,
+  ): PsiAnnotation? = delegate.findAnnotationInHierarchy(listOwner, *annotationNames)
+
+  override fun findClass(qualifiedName: String): PsiClass? = delegate.findClass(qualifiedName)
+
+  override fun findJarPath(element: PsiElement): String? = delegate.findJarPath(element)
+
+  override fun findJarPath(element: UElement): String? = delegate.findJarPath(element)
+
+  @Suppress("DEPRECATION")
+  @Deprecated(
+    "Use getAnnotations() instead; consider providing a parent",
+    replaceWith = ReplaceWith("getAnnotations(owner, inHierarchy)"),
+  )
+  override fun getAllAnnotations(
+    owner: PsiModifierListOwner,
+    inHierarchy: Boolean,
+  ): Array<PsiAnnotation> = delegate.getAllAnnotations(owner, inHierarchy)
+
+  override fun getAllAnnotations(owner: UAnnotated, inHierarchy: Boolean): List<UAnnotation> =
+    delegate.getAllAnnotations(owner, inHierarchy)
+
+  override fun getAnnotation(
+    listOwner: PsiModifierListOwner?,
+    vararg annotationNames: String,
+  ): UAnnotation? = delegate.getAnnotation(listOwner, *annotationNames)
+
+  override fun getAnnotationInHierarchy(
+    listOwner: PsiModifierListOwner,
+    vararg annotationNames: String,
+  ): UAnnotation? = delegate.getAnnotationInHierarchy(listOwner, *annotationNames)
+
+  override fun getAnnotations(
+    owner: PsiModifierListOwner?,
+    inHierarchy: Boolean,
+    parent: UElement?,
+  ): List<UAnnotation> = delegate.getAnnotations(owner, inHierarchy, parent)
+
+  override fun getClassType(psiClass: PsiClass?): PsiClassType? = delegate.getClassType(psiClass)
+
+  override fun getPackage(node: PsiElement): PsiPackage? = delegate.getPackage(node)
+
+  override fun getPackage(node: UElement): PsiPackage? = delegate.getPackage(node)
+
+  override fun getTypeClass(psiType: PsiType?): PsiClass? = delegate.getTypeClass(psiType)
+
+  override fun implementsInterface(cls: PsiClass, interfaceName: String, strict: Boolean): Boolean =
+    delegate.implementsInterface(cls, interfaceName, strict)
+
+  // endregion
+
+  /** Deep isObject check that checks if the given [cls] is an `object` class. */
+  fun isObject(cls: PsiClass?): Boolean {
+    if (cls == null) return false
+
+    (cls as? UClass ?: cls.toUElementOfType<UClass>())?.let { uClass ->
+      if (uClass.sourcePsi is KtObjectDeclaration) {
+        return true
+      } else if (canCheckMetadata(cls)) {
+        val (applicableClassKinds, isApplicable) =
+          KOTLIN_METADATA_TOKENS.getValue(KtTokens.OBJECT_KEYWORD)
+        if (uClass.javaPsi.classKind in applicableClassKinds) {
+          uClass.getOrParseMetadata()?.let { kmClass ->
+            return isApplicable(kmClass)
+          }
+        }
+      }
+    }
+    return false
+  }
+
+  private fun canCheckMetadata(element: PsiElement): Boolean {
+    return checkMetadata && element is PsiCompiledElement
+  }
+
+  override fun hasModifier(owner: PsiModifierListOwner?, keyword: KtModifierKeywordToken): Boolean {
+    val superValue = super.hasModifier(owner, keyword)
+    // If it's not a compiled element or not a PsiClass, trust the super value and move on
+    if (owner !is PsiClass || !canCheckMetadata(owner)) {
+      return superValue
+    }
+
+    // We're working with an externally compiled element and it's a PsiClass, so we can do more
+    // thorough checks here.
+    KOTLIN_METADATA_TOKENS[keyword]?.let { (applicableClassKinds, isApplicable) ->
+      owner.findContaining(UClass::class.java)?.let { cls ->
+        // Only parse if the target class kind is applicable to the token we're checking. For
+        // example - when checking `data` tokens, they're not applicable to interfaces or enums.
+        if (cls.javaPsi.classKind in applicableClassKinds) {
+          cls.getOrParseMetadata()?.let { kmClass ->
+            return isApplicable(kmClass)
+          }
+        }
+      }
+    }
+
+    return superValue
+  }
+
+  private fun UAnnotated.getOrParseMetadata(): KmClass? {
+    val cls =
+      when (this) {
+        is UClass -> this
+        else -> return null // Only classes are supported right now
+      }
+    val fqcn =
+      qualifiedName
+        ?: run {
+          metadataErrorLog("Qualified name is null for $cls in file $file")
+          return null
+        }
+    return cachedClasses
+      // Don't use getOrPut. Kotlin's extension may still invoke the body and we don't want that
+      .computeIfAbsent(fqcn) { key ->
+        val annotation =
+          cls.findAnnotation("kotlin.Metadata") ?: return@computeIfAbsent Optional.empty()
+        val (durationMillis, metadata) =
+          measureTimeMillisWithResult { annotation.parseMetadata(key) }
+        metadataLog("Took ${durationMillis}ms to parse metadata for $key.")
+        Optional.ofNullable(metadata)
+      }
+      .getOrNull()
+  }
+
+  private fun UAnnotation.parseMetadata(classNameHint: String): KmClass? {
+    val parsedMetadata =
+      try {
+        KotlinClassMetadata.readStrict(toMetadataAnnotation())
+      } catch (e: IllegalArgumentException) {
+        try {
+          KotlinClassMetadata.readLenient(toMetadataAnnotation()).also {
+            metadataErrorLog(
+              "Could not load metadata for $classNameHint from file $file with strict parsing. Using lenient parsing."
+            )
+          }
+        } catch (e: IllegalArgumentException) {
+          // Extremely weird case, log this specifically
+          metadataErrorLog(
+            "Could not load metadata for $classNameHint from file $file. This usually happens if the Kotlin version the class was compiled against is too new for lint to read (${JvmMetadataVersion.LATEST_STABLE_SUPPORTED})."
+          )
+          return null
+        }
+      }
+    return when (parsedMetadata) {
+      is KotlinClassMetadata.Class -> {
+        parsedMetadata.kmClass.also { metadataLog("Loaded KmClass for $classNameHint from file $file") }
+      }
+      else -> {
+        metadataLog(
+          """
+            Could not load KmClass for $classNameHint from file $file.
+            Metadata was $parsedMetadata
+          """
+            .trimIndent()
+        )
+        null
+      }
+    }
+  }
+
+  private fun UAnnotation.toMetadataAnnotation(): Metadata {
+    return MetadataWithNullableArgs(
+      kind = findAttributeValue("k")?.parseIntMember(),
+      metadataVersion = findAttributeValue("mv")?.parseIntArray(),
+      data1 = findAttributeValue("d1")?.parseStringArray(),
+      data2 = findAttributeValue("d2")?.parseStringArray(),
+      extraString = findAttributeValue("xs")?.parseStringMember(),
+      packageName = findAttributeValue("pn")?.parseStringMember(),
+      extraInt = findAttributeValue("xi")?.parseIntMember(),
+    )
+  }
+
+  private val PsiLiteralExpression.intValue: Int
+    get() = stringValue.toInt()
+
+  private val PsiLiteralExpression.stringValue: String
+    get() = value.toString()
+
+  private fun UExpression.parseIntMember() = (sourcePsi as PsiLiteralExpression).intValue
+
+  private fun UExpression.parseStringMember() = (sourcePsi as PsiLiteralExpression).stringValue
+
+  private fun UExpression.parseStringArray() =
+    (sourcePsi as PsiArrayInitializerMemberValue).initializers.mapArray { value ->
+      (value as PsiLiteralExpression).stringValue
+    }
+
+  private fun UExpression.parseIntArray(): IntArray {
+    val initializers = (sourcePsi as PsiArrayInitializerMemberValue).initializers
+    return IntArray(initializers.size) { index ->
+      (initializers[index] as PsiLiteralExpression).intValue
+    }
+  }
+}
+
+private inline fun <T, reified R> Array<out T>.mapArray(transform: (T) -> R): Array<R> =
+  Array(this.size) { i -> transform(this[i]) }
+
+private inline fun <T> measureTimeMillisWithResult(block: () -> T): Pair<Long, T> {
+  val start = System.currentTimeMillis()
+  val result = block()
+  return Pair(System.currentTimeMillis() - start, result)
+}
+
+private val logVerbosely by lazy {
+  System.getProperty("slack.lint.compose.logVerbosely", "false").toBoolean()
+}
+private val logErrorsVerbosely by lazy {
+  System.getProperty("slack.lint.compose.logErrorsVerbosely", "true").toBoolean()
+}
+
+/** Logs to std if `slack.lint.compose.logVerbosely` is enabled. Useful for debugging. */
+private fun metadataLog(message: String) {
+  if (logVerbosely) {
+    println("ComposeLint: $message")
+  }
+}
+
+/**
+ * Logs to std err if `slack.lint.compose.logErrorsVerbosely` is enabled. Important for errors that
+ * you don't necessarily want to fail the build.
+ */
+private fun metadataErrorLog(message: String) {
+  if (logErrorsVerbosely) {
+    System.err.println("ComposeLint: $message")
+  }
+}

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
@@ -93,7 +93,8 @@ fun PsiType.isStable(
     if (isStableAnnotated) return true
   }
 
-  // A value class is stable iff its single underlying property type is stable, mirroring the Compose
+  // A value class is stable iff its single underlying property type is stable, mirroring the
+  // Compose
   // compiler. Most callers never reach this branch because UAST already inlines a value-class type
   // to its underlying type before stability is checked; this covers the cases where the value-class
   // type itself is resolved (e.g. as a containing class).
@@ -104,8 +105,8 @@ fun PsiType.isStable(
 }
 
 /**
- * The type of a value class's single underlying property, or null if [this] isn't a value class with
- * exactly one underlying property (the only shape we can reason about today).
+ * The type of a value class's single underlying property, or null if [this] isn't a value class
+ * with exactly one underlying property (the only shape we can reason about today).
  */
 private val UClass.valueClassUnderlyingType: PsiType?
   get() {

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
@@ -93,30 +93,33 @@ fun PsiType.isStable(
     if (isStableAnnotated) return true
   }
 
-  // A value class is stable iff its single underlying property type is stable, mirroring the
-  // Compose
-  // compiler. Most callers never reach this branch because UAST already inlines a value-class type
-  // to its underlying type before stability is checked; this covers the cases where the value-class
-  // type itself is resolved (e.g. as a containing class).
-  root.valueClassUnderlyingType?.let {
-    return it.isStable(evaluator)
+  // A value class is stable iff its single underlying property type is stable, mirroring the Compose
+  // compiler. Most callers never reach this branch because UAST already inlines a value-class type to
+  // its underlying type before stability is checked; this covers the cases where the value-class type
+  // itself is resolved (e.g. as a containing class), including compiled cross-module classes when a
+  // [MetadataJavaEvaluator] is supplied.
+  if (evaluator.isValueClass(root)) {
+    // If we can't resolve the underlying type (e.g. a compiled class with no source), assume stable
+    // since value classes overwhelmingly wrap stable primitives.
+    return root.valueClassUnderlyingType?.isStable(evaluator) ?: true
   }
   return false
 }
 
-/**
- * The type of a value class's single underlying property, or null if [this] isn't a value class
- * with exactly one underlying property (the only shape we can reason about today).
- */
+private fun JavaEvaluator.isValueClass(uClass: UClass): Boolean {
+  // @JvmInline is required on (and binary-retained for) all JVM value classes, so this catches both
+  // source and compiled classes. A [MetadataJavaEvaluator] additionally reads the `value` modifier
+  // from Kotlin metadata for compiled cross-module classes (i.e. when checkDependencies=false).
+  return uClass.hasAnnotation(JVM_INLINE) || hasModifier(uClass.javaPsi, KtTokens.VALUE_KEYWORD)
+}
+
+/** The type of a value class's single underlying property, if resolvable from source. */
 private val UClass.valueClassUnderlyingType: PsiType?
-  get() {
-    val ktClass = sourcePsi as? KtClass ?: return null
-    val isValueClass = hasAnnotation(JVM_INLINE) || ktClass.hasModifier(KtTokens.VALUE_KEYWORD)
-    if (!isValueClass) return null
-    return ktClass.primaryConstructor
+  get() =
+    (sourcePsi as? KtClass)
+      ?.primaryConstructor
       ?.valueParameters
       ?.singleOrNull()
       ?.typeReference
       ?.toUElementOfType<UTypeReferenceExpression>()
       ?.type
-  }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
@@ -93,9 +93,12 @@ fun PsiType.isStable(
     if (isStableAnnotated) return true
   }
 
-  // A value class is stable iff its single underlying property type is stable, mirroring the Compose
-  // compiler. Most callers never reach this branch because UAST already inlines a value-class type to
-  // its underlying type before stability is checked; this covers the cases where the value-class type
+  // A value class is stable iff its single underlying property type is stable, mirroring the
+  // Compose
+  // compiler. Most callers never reach this branch because UAST already inlines a value-class type
+  // to
+  // its underlying type before stability is checked; this covers the cases where the value-class
+  // type
   // itself is resolved (e.g. as a containing class), including compiled cross-module classes when a
   // [MetadataJavaEvaluator] is supplied.
   if (evaluator.isValueClass(root)) {

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Stability.kt
@@ -5,13 +5,17 @@ package slack.lint.compose.util
 import com.android.tools.lint.client.api.JavaEvaluator
 import com.intellij.psi.PsiType
 import com.intellij.psi.PsiTypes
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UTypeReferenceExpression
 import org.jetbrains.uast.toUElementOfType
 
 private const val COMPOSE_STABLE = "androidx.compose.runtime.Stable"
 private const val COMPOSE_IMMUTABLE = "androidx.compose.runtime.Immutable"
 private const val COMPOSE_STABLE_MARKER = "androidx.compose.runtime.StableMarker"
+private const val JVM_INLINE = "kotlin.jvm.JvmInline"
 
 val STABILITY_ANNOTATIONS = setOf(COMPOSE_STABLE, COMPOSE_IMMUTABLE)
 
@@ -88,5 +92,30 @@ fun PsiType.isStable(
       }
     if (isStableAnnotated) return true
   }
+
+  // A value class is stable iff its single underlying property type is stable, mirroring the Compose
+  // compiler. Most callers never reach this branch because UAST already inlines a value-class type
+  // to its underlying type before stability is checked; this covers the cases where the value-class
+  // type itself is resolved (e.g. as a containing class).
+  root.valueClassUnderlyingType?.let {
+    return it.isStable(evaluator)
+  }
   return false
 }
+
+/**
+ * The type of a value class's single underlying property, or null if [this] isn't a value class with
+ * exactly one underlying property (the only shape we can reason about today).
+ */
+private val UClass.valueClassUnderlyingType: PsiType?
+  get() {
+    val ktClass = sourcePsi as? KtClass ?: return null
+    val isValueClass = hasAnnotation(JVM_INLINE) || ktClass.hasModifier(KtTokens.VALUE_KEYWORD)
+    if (!isValueClass) return null
+    return ktClass.primaryConstructor
+      ?.valueParameters
+      ?.singleOrNull()
+      ?.typeReference
+      ?.toUElementOfType<UTypeReferenceExpression>()
+      ?.type
+  }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/StabilityChecks.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/StabilityChecks.kt
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose.util
+
+import com.android.tools.lint.detector.api.BooleanOption
+import com.android.tools.lint.detector.api.JavaContext
+
+/**
+ * Shared option gating the Compose stability checks (`ComposeUnstableReceiver`,
+ * `ComposeMutableParameters`, and `ComposeUnstableCollections`).
+ *
+ * These are significantly less important in the era of Compose strong skipping, which makes
+ * composables skippable regardless of parameter/receiver stability, so they are disabled by default
+ * and must be explicitly enabled.
+ */
+val STABILITY_CHECKS_OPTION =
+  BooleanOption(
+    "stability-checks",
+    "Enable Compose stability checks (unstable receivers, mutable parameters, unstable collections)",
+    false,
+    "Stability-related checks are significantly less important now that Compose strong skipping is " +
+      "widely available, so they are disabled by default. Set this to true to re-enable them. See " +
+      "https://slackhq.github.io/compose-lints/rules/#stability for more information.",
+  )
+
+/** Whether the [STABILITY_CHECKS_OPTION] is enabled for the current [JavaContext]. */
+fun JavaContext.stabilityChecksEnabled(): Boolean = STABILITY_CHECKS_OPTION.getValue(this)

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
+import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.android.tools.lint.checks.infrastructure.TestMode
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
+import slack.lint.compose.util.STABILITY_CHECKS_OPTION
 
 class MutableParametersDetectorTest : BaseComposeLintTest() {
 
@@ -18,6 +20,25 @@ class MutableParametersDetectorTest : BaseComposeLintTest() {
   // Can't get typealias working correctly in this case as the combination of an
   // alias + lint's inability to reach kotlin intrinsic collections defeats it
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.TYPE_ALIAS)
+
+  // Stability checks are off by default; enable them for these tests.
+  override fun lint(): TestLintTask = super.lint().configureOption(STABILITY_CHECKS_OPTION, true)
+
+  @Test
+  fun `stability checks are disabled by default`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.MutableState
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Something(a: MutableState<String>) {}
+      """
+        .trimIndent()
+    // Note super.lint() to avoid enabling the option.
+    super.lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
 
   @Test
   fun `errors when a Composable has a mutable parameter`() {

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableCollectionsDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableCollectionsDetectorTest.kt
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
+import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.android.tools.lint.checks.infrastructure.TestMode
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
+import slack.lint.compose.util.STABILITY_CHECKS_OPTION
 
 class UnstableCollectionsDetectorTest : BaseComposeLintTest() {
 
@@ -18,6 +20,24 @@ class UnstableCollectionsDetectorTest : BaseComposeLintTest() {
   // Can't get typealias working correctly in this case as the combination of an
   // alias + lint's inability to reach kotlin intrinsic collections defeats it
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.TYPE_ALIAS)
+
+  // Stability checks are off by default; enable them for these tests.
+  override fun lint(): TestLintTask = super.lint().configureOption(STABILITY_CHECKS_OPTION, true)
+
+  @Test
+  fun `stability checks are disabled by default`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Something(a: List<String>) {}
+      """
+        .trimIndent()
+    // Note super.lint() to avoid enabling the option.
+    super.lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
 
   @Test
   fun `warnings when a Composable has a Collection List Set Map parameter`() {

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
@@ -141,6 +141,90 @@ class UnstableReceiverDetectorTest : BaseComposeLintTest() {
       )
   }
 
+  // https://github.com/slackhq/compose-lints/issues/326
+  @Test
+  fun `composable property getter with non-Unit return on value class receiver reports no errors`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.runtime.Immutable
+
+      @Immutable
+      @kotlin.jvm.JvmInline
+      value class Color(val value: ULong) {
+        fun copy(alpha: Float): Color = this
+      }
+
+      public val Color.transparent: Color
+          @Composable get() = this.copy(alpha = 0f)
+      """
+        .trimIndent()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  // Regression for the value-class receiver path: K2 UAST doesn't surface the receiver of a
+  // value-class extension as a uast parameter, and (for property getters) treats the declaration as
+  // non-top-level so its containing file facade (*Kt) is checked as the "containing class". Neither
+  // the missing receiver param nor the facade should be treated as an unstable receiver. The getter
+  // forms below are the ones that previously false-positived.
+  @Test
+  fun `composable extensions on value class receivers report no errors`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.runtime.Immutable
+
+      @Immutable
+      @kotlin.jvm.JvmInline
+      value class Color(val value: ULong)
+
+      // Underlying type is stable even without an explicit stability annotation.
+      @kotlin.jvm.JvmInline
+      value class Dollars(val amount: Int)
+
+      @Composable
+      fun Color.Render() {}
+
+      @Composable
+      fun Dollars.Render() {}
+
+      val Color.rendered: Unit
+          @Composable get() {}
+
+      val Dollars.rendered: Unit
+          @Composable get() {}
+      """
+        .trimIndent()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  // A value/inline class is stable iff its underlying property type is stable, so composable members
+  // of one (whose containing class is the receiver) shouldn't be flagged.
+  @Test
+  fun `composable members of value classes report no errors`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.runtime.Immutable
+
+      @kotlin.jvm.JvmInline
+      value class Dollars(val amount: Int) {
+        @Composable fun Render() {}
+      }
+
+      @Immutable
+      @kotlin.jvm.JvmInline
+      value class Color(val value: ULong) {
+        @Composable fun Render() {}
+      }
+      """
+        .trimIndent()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
   @Test
   fun `unstable receiver types with non-Unit return type report no errors`() {
     @Language("kotlin")

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
@@ -200,7 +200,8 @@ class UnstableReceiverDetectorTest : BaseComposeLintTest() {
     lint().files(*commonStubs, kotlin(code)).run().expectClean()
   }
 
-  // A value/inline class is stable iff its underlying property type is stable, so composable members
+  // A value/inline class is stable iff its underlying property type is stable, so composable
+  // members
   // of one (whose containing class is the receiver) shouldn't be flagged.
   @Test
   fun `composable members of value classes report no errors`() {

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
@@ -2,16 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
+import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
 import org.junit.Test
+import slack.lint.compose.util.STABILITY_CHECKS_OPTION
 
 class UnstableReceiverDetectorTest : BaseComposeLintTest() {
 
   override fun getDetector(): Detector = UnstableReceiverDetector()
 
   override fun getIssues(): List<Issue> = listOf(UnstableReceiverDetector.ISSUE)
+
+  // Stability checks are off by default; enable them for these tests.
+  override fun lint(): TestLintTask = super.lint().configureOption(STABILITY_CHECKS_OPTION, true)
+
+  @Test
+  fun `stability checks are disabled by default`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      class Example {
+        @Composable fun Content() {}
+      }
+      """
+        .trimIndent()
+    // Note super.lint() to avoid enabling the option.
+    super.lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
 
   @Test
   fun `stable receiver types report no errors`() {

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,3 +1,25 @@
+## Stability
+
+A handful of rules ([`ComposeUnstableReceiver`](#unstable-receivers), [`ComposeMutableParameters`](#do-not-use-inherently-mutable-types-as-parameters), and [`ComposeUnstableCollections`](#avoid-using-unstable-collections)) exist to flag parameters and receivers whose instability would prevent a composable from being skipped during recomposition.
+
+These are **significantly less important in the era of [Compose strong skipping](https://developer.android.com/develop/ui/compose/performance/stability/strongskipping)**, which makes composables skippable regardless of parameter/receiver stability. Because of that, they are **disabled by default**.
+
+To opt back in, enable the `stability-checks` option in `lint.xml`. The option is shared by all three rules, so set it on each rule you want to turn on:
+
+```xml
+<lint>
+   <issue id="ComposeUnstableReceiver">
+      <option name="stability-checks" value="true" />
+   </issue>
+   <issue id="ComposeMutableParameters">
+      <option name="stability-checks" value="true" />
+   </issue>
+   <issue id="ComposeUnstableCollections">
+      <option name="stability-checks" value="true" />
+   </issue>
+</lint>
+```
+
 ## State
 
 ### Hoist all the things
@@ -50,6 +72,9 @@ val list: StringList = StringList(yourList)
 > **Note**: It is preferred to use Kotlinx Immutable Collections for this. As you can see, the wrapped case only includes the immutability promise with the annotation, but the underlying List is still mutable.
 More info: [Jetpack Compose Stability Explained](https://medium.com/androiddevelopers/jetpack-compose-stability-explained-79c10db270c8), [Kotlinx Immutable Collections](https://github.com/Kotlin/kotlinx.collections.immutable)
 
+!!! note "Disabled by default"
+    This is a [stability check](#stability) and is disabled by default. Enable it with the `stability-checks` option.
+
 Related rule: [`ComposeUnstableCollections`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/UnstableCollectionsDetector.kt)
 
 ## Composables
@@ -64,6 +89,9 @@ There are a few reasons for this, but the main one is that it is very easy to us
 
 Passing `ArrayList<T>`, `MutableState<T>`, `ViewModel` are common examples of this (but not limited to those types).
 
+!!! note "Disabled by default"
+    This is a [stability check](#stability) and is disabled by default. Enable it with the `stability-checks` option.
+
 Related rule: [`ComposeMutableParameters`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/MutableParametersDetector.kt)
 
 ### Unstable receivers
@@ -71,8 +99,8 @@ Related rule: [`ComposeMutableParameters`](https://github.com/slackhq/compose-li
 In compose, all parameters must be stable or immutable in order for a composable function to be
 _restartable_ or _skippable_. This _includes_ the containing class or receiver, which the compose-compiler will treat as the 0th argument. Using an unstable receiver is usually a bug, so this lint offers a warning to raise this issue.
 
-!!! warning "Use with Strong Skipping"
-If you have Strong Skipping enabled, we recommend disabling this rule to avoid potential false negatives.
+!!! note "Disabled by default"
+    This is a [stability check](#stability) and is disabled by default — it is largely obsoleted by Strong Skipping. Enable it with the `stability-checks` option.
 
 More info: [Compose API Stability](https://developer.android.com/jetpack/compose/performance/stability)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,12 +13,14 @@ lint = { id = "com.android.lint", version = "9.2.1" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version = "2.3.8" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
+shadow = { id = "com.gradleup.shadow", version = "9.4.1" }
 spotless = { id = "com.diffplug.spotless", version = "8.5.1" }
 
 [libraries]
 autoService-annotations = "com.google.auto.service:auto-service-annotations:1.1.1"
 autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.2.0"
 junit = "junit:junit:4.13.2"
+kotlin-metadata = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "lint" }


### PR DESCRIPTION
Stability checks don't matter nearly as much in strong skipping modes, so this disables them by default with an option to enable. This also fixes value class detection along the way (resolves #326) and pulls slack-lints' metadata evaluator.

Note this doesn't purely rely on just disabling the lint by default via lint's mechanism because that still runs them!