### PR TITLE
Add backtick to enable code reference formatting in lint output

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ParameterOrderDetector.kt
@@ -38,7 +38,7 @@ class ParameterOrderDetector : ComposableFunctionDetector(), SourceCodeScanner {
     private fun createErrorMessage(currentOrder: String, properOrder: String): String =
       """
         Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
-        Current params are: [$currentOrder] but should be [$properOrder].
+        Current params are: `[$currentOrder]` but should be `[$properOrder]`.
         See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information.
       """
         .trimIndent()


### PR DESCRIPTION
Quick example:

- from:
  Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
Current params are: [question: Question, modifier: Modifier = Modifier, onQuestionRated: (Int) -> Unit, onTextReviewChange: (String) -> Unit] but should be [question: Question, onQuestionRated: (Int) -> Unit, modifier: Modifier = Modifier, onTextReviewChange: (String) -> Unit].

- to:
  Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
Current params are: `[question: Question, modifier: Modifier = Modifier, onQuestionRated: (Int) -> Unit, onTextReviewChange: (String) -> Unit]` but should be `[question: Question, onQuestionRated: (Int) -> Unit, modifier: Modifier = Modifier, onTextReviewChange: (String) -> Unit]`.