### PR TITLE
fix: ComposeRedundantComposable false positive for typeliased Composable slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 **Unreleased**
 --------------
 
+- **Enhancement**: See through typealiases when detecting `@Composable` functions in parameters.
+- **Fix**: Fix a few false positives with the new `ComposeRedundantComposable` check.
+
+Special thanks to [@eboudrant](https://github.com/eboudrant) and [@kboyarshinov](https://github.com/kboyarshinov) for contributing to this release!
+
 1.5.1
 -----
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
@@ -5,6 +5,12 @@ package slack.lint.compose.util
 
 import com.android.tools.lint.client.api.JavaEvaluator
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.fullyExpandedType
+import org.jetbrains.kotlin.analysis.api.symbols.symbol
+import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
@@ -175,8 +181,7 @@ val ModifierQualifiedNames by
     setOf("androidx.compose.ui.Modifier", "androidx.glance.GlanceModifier")
   }
 
-val KtCallableDeclaration.isModifier: Boolean
-  get() = ModifierNames.contains(typeReference?.text)
+private val ComposableClassId = ClassId.topLevel(FqName("androidx.compose.runtime.Composable"))
 
 fun UParameter.isModifier(evaluator: JavaEvaluator): Boolean {
   (sourcePsi as? KtParameter)?.let {
@@ -189,30 +194,35 @@ fun UParameter.isModifier(evaluator: JavaEvaluator): Boolean {
 }
 
 fun UParameter.isSlotParameter(): Boolean {
-  // Check if the parameter type has a @Composable annotation
   val ktParam = sourcePsi as? KtParameter ?: return false
-  var typeRef = ktParam.typeReference ?: return false
-  // Loop to expand typealias chains (e.g. `typealias A = B`, `typealias B = @Composable () -> Unit`).
-  while (true) {
-    // Check if any annotation on the type reference is @Composable
-    val hasComposableAnnotation =
+  val typeRef = ktParam.typeReference ?: return false
+
+  // Fast, happy path check
+  val isSimpleComposableFunction =
+    typeRef.typeElement is KtFunctionType &&
       typeRef.annotationEntries.any { annotation ->
         annotation.shortName?.asString() == "Composable" ||
           annotation.text?.contains("Composable") == true
       }
-    // Check if the type is a function type (using the KtFunctionType PSI directly)
-    val typeElement = typeRef.typeElement
-    if (hasComposableAnnotation) return typeElement is KtFunctionType
-    // Also handle typealiases: `typealias Foo = @Composable () -> Unit`
-    typeRef =
-      (typeElement as? KtUserType)
-        ?.referenceExpression
-        ?.references
-        ?.firstOrNull()
-        ?.resolve()
-        ?.let { it as? KtTypeAlias }
-        ?.getTypeReference() ?: return false
+
+  if (isSimpleComposableFunction) {
+    return true
   }
+
+  return if (typeRef.isTypeAlias()) {
+    // If it's a typealias, fall through to a more thorough check
+    analyze(ktParam) {
+      val type = ktParam.symbol.returnType.fullyExpandedType
+      type is KaFunctionType && ComposableClassId in type.annotations
+    }
+  } else {
+    false
+  }
+}
+
+private fun KtTypeReference.isTypeAlias(): Boolean {
+  return (typeElement as? KtUserType)?.referenceExpression?.references?.firstOrNull()?.resolve() is
+    KtTypeAlias
 }
 
 val KtCallableDeclaration.isModifierReceiver: Boolean

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
@@ -8,9 +8,13 @@ import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UParameter
@@ -187,17 +191,28 @@ fun UParameter.isModifier(evaluator: JavaEvaluator): Boolean {
 fun UParameter.isSlotParameter(): Boolean {
   // Check if the parameter type has a @Composable annotation
   val ktParam = sourcePsi as? KtParameter ?: return false
-  val typeRef = ktParam.typeReference ?: return false
-  // Check if any annotation on the type reference is @Composable
-  val hasComposableAnnotation =
-    typeRef.annotationEntries.any { annotation ->
-      annotation.shortName?.asString() == "Composable" ||
-        annotation.text?.contains("Composable") == true
-    }
-  if (!hasComposableAnnotation) return false
-  // Check if the type is a function type (using the KtFunctionType PSI directly)
-  val typeElement = typeRef.typeElement
-  return typeElement is org.jetbrains.kotlin.psi.KtFunctionType
+  var typeRef = ktParam.typeReference ?: return false
+  // Loop to expand typealias chains (e.g. `typealias A = B`, `typealias B = @Composable () -> Unit`).
+  while (true) {
+    // Check if any annotation on the type reference is @Composable
+    val hasComposableAnnotation =
+      typeRef.annotationEntries.any { annotation ->
+        annotation.shortName?.asString() == "Composable" ||
+          annotation.text?.contains("Composable") == true
+      }
+    // Check if the type is a function type (using the KtFunctionType PSI directly)
+    val typeElement = typeRef.typeElement
+    if (hasComposableAnnotation) return typeElement is KtFunctionType
+    // Also handle typealiases: `typealias Foo = @Composable () -> Unit`
+    typeRef =
+      (typeElement as? KtUserType)
+        ?.referenceExpression
+        ?.references
+        ?.firstOrNull()
+        ?.resolve()
+        ?.let { it as? KtTypeAlias }
+        ?.getTypeReference() ?: return false
+  }
 }
 
 val KtCallableDeclaration.isModifierReceiver: Boolean

--- a/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
@@ -186,7 +186,7 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
         println("doesn't even call content")
       }
       """
-         .trimIndent()
+        .trimIndent()
     lint().files(stubs, kotlin(code)).run().expectClean()
   }
 

--- a/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
@@ -173,6 +173,24 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun `no errors for composables that take typealiased composable slot`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      typealias ComposableTypealias = @Composable () -> Unit
+
+      @Composable
+      fun Wrapper(content: ComposableTypealias) {
+        println("doesn't even call content")
+      }
+      """
+         .trimIndent()
+    lint().files(stubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
   fun `no errors for overrides and overridable declarations`() {
     @Language("kotlin")
     val code =


### PR DESCRIPTION
Fix for another false positive with `ComposeRedundantComposable`: https://github.com/slackhq/compose-lints/issues/558#issuecomment-4603533303.

Solution loops through typealias chain, so it will be longer than just checking 1 type. This can also be limited to 1 or 2 loops, as I don't think it's realistic to have long typealias chain for composable lambda.