### PR TITLE
Improve context param handling with multiple content emitters

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtForExpression
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.uast.UFile
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.kotlin.isKotlin
@@ -39,6 +40,9 @@ constructor(
 
     val CONTENT_EMITTER_OPTION = ContentEmitterLintOption.newOption()
 
+    private val ContextParameterNameRegex =
+      Regex("""(?:\bcontext\s*\(|,)\s*([A-Za-z_][A-Za-z0-9_]*|_)\s*:""")
+
     val ISSUE =
       Issue.create(
           id = "ComposeMultipleContentEmitters",
@@ -60,6 +64,13 @@ constructor(
   internal val KtFunction.directUiEmitterCount: Int
     get() {
       return bodyBlockExpression?.let { block ->
+        val directUiEmitterCalls = block.directUiEmitterCalls
+        val directUiEmitterCount =
+          if (directUiEmitterCalls.areAllScopedToContextParameters(contextParameterNames)) {
+            0
+          } else {
+            directUiEmitterCalls.size
+          }
         // If there's content emitted in a for loop, we assume there's at
         // least two iterations and thus count any emitters in them as multiple
         val forLoopCount =
@@ -68,7 +79,7 @@ constructor(
           } else {
             0
           }
-        block.directUiEmitterCount + forLoopCount
+        directUiEmitterCount + forLoopCount
       } ?: 0
     }
 
@@ -88,34 +99,35 @@ constructor(
     }
 
   internal val KtBlockExpression.directUiEmitterCount: Int
-    get() {
-      return statements
-        .mapNotNull { it.unwrapParenthesis() }
-        .filterIsInstance<KtCallExpression>()
-        .count { it.emitsContent(contentEmitterOption.value) }
-    }
+    get() = directUiEmitterCalls.size
 
   internal fun KtFunction.indirectUiEmitterCount(mapping: Map<KtFunction, Int>): Int {
     val bodyBlock = bodyBlockExpression ?: return 0
-    return bodyBlock.statements
-      .mapNotNull { it.unwrapParenthesis() }
-      .filterIsInstance<KtCallExpression>()
-      .count { callExpression ->
-        // If it's a direct hit on our list, it should count directly
-        if (callExpression.emitsContent(contentEmitterOption.value)) return@count true
+    val contextParameterNames = contextParameterNames
+    val indirectUiEmitterCalls =
+      bodyBlock.statements
+        .mapNotNull { it.unwrapParenthesis() }
+        .filterIsInstance<KtCallExpression>()
+        .filter { callExpression ->
+          // If it's a direct hit on our list, it should count directly
+          if (callExpression.emitsContent(contentEmitterOption.value)) return@filter true
 
-        val name = callExpression.calleeExpression?.text ?: return@count false
-        // If the hit is in the provided mapping, it means it is using a composable that we know
-        // emits
-        // UI, that we inferred from previous passes
-        val value =
-          mapping
-            .mapKeys { entry -> entry.key.name }
-            .getOrElse(name) {
-              return@count false
-            }
-        value > 0
-      }
+          val name = callExpression.calleeExpression?.text ?: return@filter false
+          // If the hit is in the provided mapping, it means it is using a composable that we know
+          // emits UI, that we inferred from previous passes
+          val value =
+            mapping
+              .mapKeys { entry -> entry.key.name }
+              .getOrElse(name) {
+                return@filter false
+              }
+          value > 0
+        }
+    return if (indirectUiEmitterCalls.areAllScopedToContextParameters(contextParameterNames)) {
+      0
+    } else {
+      indirectUiEmitterCalls.size
+    }
   }
 
   override fun getApplicableUastTypes() = listOf(UFile::class.java)
@@ -135,10 +147,6 @@ constructor(
             // things like
             // BoxScope which are legit, and we want to avoid false positives.
             .filter { it.hasBlockBody() }
-            // Same applies to context receivers/parameters: we could have a
-            // BoxScope/ColumnScope/RowScope and it'd be legit.
-            // We don't have a way to know for sure, so we'd better avoid the issue altogether.
-            .filter { it.contextReceivers.isEmpty() }
             // We want only methods with a body
             .filterNot { it.hasReceiverType }
 
@@ -198,4 +206,47 @@ constructor(
       }
     }
   }
+
+  private val KtFunction.contextParameterNames: Set<String>
+    get() {
+      return ContextParameterNameRegex.findAll(text.substringBefore("{")).mapNotNullTo(
+        mutableSetOf()
+      ) { match ->
+        match.groupValues[1].takeUnless { name -> name == "_" }
+      }
+    }
+
+  private val KtBlockExpression.directUiEmitterCalls: List<KtCallExpression>
+    get() {
+      return statements
+        .mapNotNull { it.unwrapParenthesis() }
+        .filterIsInstance<KtCallExpression>()
+        .filter { it.emitsContent(contentEmitterOption.value) }
+    }
+
+  private fun List<KtCallExpression>.areAllScopedToContextParameters(
+    contextParameterNames: Set<String>
+  ): Boolean {
+    return size > 1 &&
+      contextParameterNames.isNotEmpty() &&
+      all { it.referencesAnyContextParameter(contextParameterNames) }
+  }
+
+  private fun KtCallExpression.referencesAnyContextParameter(
+    contextParameterNames: Set<String>
+  ): Boolean {
+    return findChildrenByClass<KtSimpleNameExpression>().any {
+      it.getReferencedName() in contextParameterNames
+    } || contextParameterNames.any { text.containsIdentifier(it) }
+  }
+
+  private fun String.containsIdentifier(name: String): Boolean {
+    return windowed(name.length, partialWindows = false).withIndex().any { (index, value) ->
+      value == name &&
+        getOrNull(index - 1)?.isIdentifierPart() != true &&
+        getOrNull(index + name.length)?.isIdentifierPart() != true
+    }
+  }
+
+  private fun Char.isIdentifierPart(): Boolean = isLetterOrDigit() || this == '_' || this == '$'
 }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt
@@ -135,8 +135,8 @@ constructor(
             // things like
             // BoxScope which are legit, and we want to avoid false positives.
             .filter { it.hasBlockBody() }
-            // Same applies to context receivers: we could have a BoxScope/ColumnScope/RowScope
-            // and it'd be legit.
+            // Same applies to context receivers/parameters: we could have a
+            // BoxScope/ColumnScope/RowScope and it'd be legit.
             // We don't have a way to know for sure, so we'd better avoid the issue altogether.
             .filter { it.contextReceivers.isEmpty() }
             // We want only methods with a body

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
@@ -61,28 +61,127 @@ class MultipleContentEmittersDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
-  fun `passes when the composable is a context receiver or parameter`() {
+  fun `passes when multiple top-level emitters thread a context parameter`() {
     @Language("kotlin")
     val code =
       """
-      context(ColumnScope)
+      import androidx.compose.runtime.Composable
+
+      class Modifier
+
       @Composable
-      fun Something() {
-          Text("Hi")
-          Text("Hola")
+      fun Text(text: String, modifier: Modifier) {}
+
+      interface RowScope {
+          fun itemModifier(): Modifier
       }
 
       context(scope: RowScope)
       @Composable
       fun Something() {
-          with(scope) {
-              Text("Hi", Modifier.weight(1f))
-          }
-          Text("Hola")
+          WeightedText("Hi", scope.itemModifier())
+          WeightedText("Hola", scope.itemModifier())
+      }
+
+      @Composable
+      fun WeightedText(text: String, modifier: Modifier) {
+          Text(text, modifier)
       }
       """
         .trimIndent()
-    lint().files(kotlin(code)).allowCompilationErrors().run().expectClean()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `errors when multiple top-level emitters ignore a context parameter`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      class Modifier
+
+      val DefaultModifier = Modifier()
+
+      @Composable
+      fun Text(text: String, modifier: Modifier) {}
+
+      interface RowScope
+
+      context(scope: RowScope)
+      @Composable
+      fun Something() {
+          WeightedText("Hi", DefaultModifier)
+          WeightedText("Hola", DefaultModifier)
+      }
+
+      @Composable
+      fun WeightedText(text: String, modifier: Modifier) {
+          Text(text, modifier)
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/Modifier.kt:12: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+        context(scope: RowScope)
+        ^
+        1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors when only some top-level emitters use a context parameter`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      class Modifier
+
+      val DefaultModifier = Modifier()
+
+      @Composable
+      fun Text(text: String, modifier: Modifier) {}
+
+      interface RowScope {
+          fun itemModifier(): Modifier
+      }
+
+      context(scope: RowScope)
+      @Composable
+      fun Something() {
+          WeightedText("Hi", scope.itemModifier())
+          WeightedText("Hola", DefaultModifier)
+      }
+
+      @Composable
+      fun WeightedText(text: String, modifier: Modifier) {
+          Text(text, modifier)
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/Modifier.kt:14: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+        context(scope: RowScope)
+        ^
+        1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
   }
 
   @Test

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
@@ -61,7 +61,7 @@ class MultipleContentEmittersDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
-  fun `passes when the composable is a context receiver`() {
+  fun `passes when the composable is a context receiver or parameter`() {
     @Language("kotlin")
     val code =
       """
@@ -71,10 +71,13 @@ class MultipleContentEmittersDetectorTest : BaseComposeLintTest() {
           Text("Hi")
           Text("Hola")
       }
-      context(RowScope)
+
+      context(scope: RowScope)
       @Composable
       fun Something() {
-          Spacer16()
+          with(scope) {
+              Text("Hi", Modifier.weight(1f))
+          }
           Text("Hola")
       }
       """

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -181,13 +181,18 @@ private fun ColumnScope.InnerContent() {
 context(scope: ColumnScope)
 @Composable
 private fun InnerContent() {
+    WeightedText("Title", scope)
+    WeightedText("Subtitle", scope)
+}
+
+@Composable
+private fun WeightedText(text: String, scope: ColumnScope) {
     with(scope) {
-        Text(..., Modifier.weight(1f))
+        Text(text, Modifier.weight(1f))
     }
-    Image(...)
 }
 ```
-This effectively ties the function to be called from a Column, but is still not recommended (although permitted).
+This effectively ties the function to be called from a Column, but is still not recommended (although permitted). Context parameter exceptions are only allowed when the emitted calls actually use the context parameter.
 
 Related rule: [`ComposeMultipleContentEmitters`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/MultipleContentEmittersDetector.kt)
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -168,13 +168,23 @@ private fun InnerContent() {
 ```
 Nesting of layouts has a drastically lower cost vs the view system, so developers should not try to minimize UI layers at the cost of correctness.
 
-There is a slight exception to this rule, which is when the function is defined as an extension function of an appropriate scope, like so:
+There is a slight exception to this rule, which is when the function is tied to an appropriate scope with an extension receiver or context parameter, like so:
+
 ```kotlin
 @Composable
 private fun ColumnScope.InnerContent() {
     Text(...)
     Image(...)
     Button(...)
+}
+
+context(scope: ColumnScope)
+@Composable
+private fun InnerContent() {
+    with(scope) {
+        Text(..., Modifier.weight(1f))
+    }
+    Image(...)
 }
 ```
 This effectively ties the function to be called from a Column, but is still not recommended (although permitted).


### PR DESCRIPTION
Resolves #557. We did technically sort of support it before but we didn't actually check their usage.