### PR TITLE
ComposeRedundantComposable false positive when invoking a @Composable function-typed value held in a property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 **Unreleased**
 --------------
 
+- **Fix**: Fix false positive in `ComposeRedundantComposable` when invoking composable function parameters in the body.
+
+Special thanks to [@UniqueEVE](https://github.com/UniqueEVE) for contributing to this release!
+
 1.5.2
 -----
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.asJava.unwrapped
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.psi.psiUtil.isTopLevelKtOrJavaMember
@@ -28,6 +29,7 @@ import org.jetbrains.uast.toUElementOfType
 import org.jetbrains.uast.visitor.AbstractUastVisitor
 import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isComposable
+import slack.lint.compose.util.isComposableFunctionType
 import slack.lint.compose.util.slotParameters
 import slack.lint.compose.util.sourceImplementation
 
@@ -43,9 +45,10 @@ import slack.lint.compose.util.sourceImplementation
  * or that take a `@Composable` lambda parameter (a "slot", which is generally invoked). Reading or
  * writing a `androidx.compose.runtime.State`'s `value` is also treated as composition usage: while
  * it isn't technically a `@Composable` operation, it signals intentional use of Compose state
- * (often kept `@Composable` for a tighter recomposition scope), so we don't flag it. It can still
- * miss some removable cases (e.g., invoking a `@Composable` lambda stored in a local with an
- * inferred type), which is the safe direction.
+ * (often kept `@Composable` for a tighter recomposition scope), so we don't flag it. Invoking a
+ * value whose type is a `@Composable` function type (such as a `@Composable () -> Unit` held in a
+ * property or local) also counts as composition usage. It can still miss some removable cases,
+ * which is the safe direction.
  */
 class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
@@ -143,7 +146,9 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
     accept(
       object : AbstractUastVisitor() {
         override fun visitCallExpression(node: UCallExpression): Boolean {
-          if (!usesComposition && node.resolve().isComposable()) usesComposition = true
+          if (!usesComposition && (node.resolve().isComposable() || node.invokesComposableLambda())) {
+            usesComposition = true
+          }
           return usesComposition
         }
 
@@ -178,6 +183,11 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
 
   private fun PsiMethod?.isComposable(): Boolean =
     this?.toUElementOfType<UMethod>()?.isComposable == true
+
+  private fun UCallExpression.invokesComposableLambda(): Boolean {
+    val callee = (sourcePsi as? KtCallExpression)?.calleeExpression ?: return false
+    return callee.isComposableFunctionType()
+  }
 }
 
 private val MODALITY_MODIFIERS =

--- a/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
@@ -29,7 +29,7 @@ import org.jetbrains.uast.toUElementOfType
 import org.jetbrains.uast.visitor.AbstractUastVisitor
 import slack.lint.compose.util.Priorities
 import slack.lint.compose.util.isComposable
-import slack.lint.compose.util.isComposableFunctionType
+import slack.lint.compose.util.hasComposableFunctionType
 import slack.lint.compose.util.slotParameters
 import slack.lint.compose.util.sourceImplementation
 
@@ -188,7 +188,7 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
 
   private fun UCallExpression.invokesComposableLambda(): Boolean {
     val callee = (sourcePsi as? KtCallExpression)?.calleeExpression ?: return false
-    return callee.isComposableFunctionType()
+    return callee.hasComposableFunctionType()
   }
 }
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
@@ -28,27 +28,19 @@ import org.jetbrains.uast.getContainingUClass
 import org.jetbrains.uast.toUElementOfType
 import org.jetbrains.uast.visitor.AbstractUastVisitor
 import slack.lint.compose.util.Priorities
-import slack.lint.compose.util.isComposable
 import slack.lint.compose.util.hasComposableFunctionType
+import slack.lint.compose.util.isComposable
 import slack.lint.compose.util.slotParameters
 import slack.lint.compose.util.sourceImplementation
 
 /**
- * Reports `@Composable` functions and property getters whose body doesn't actually use the
- * composition, meaning they don't call any other `@Composable` function or read a `@Composable`
- * property (such as a `CompositionLocal`'s `current`). In those cases the `@Composable` annotation
- * can be removed.
+ * Reports `@Composable` functions and property getters that can be made non-composable.
  *
- * This is conservative to avoid false positives: it only reports when no composition usage is found
- * anywhere in the body, and it skips declarations where removing the annotation would break a
- * contract (overrides, `open`/`abstract` members, interface members, `expect`/`actual`/`external`)
- * or that take a `@Composable` lambda parameter (a "slot", which is generally invoked). Reading or
- * writing a `androidx.compose.runtime.State`'s `value` is also treated as composition usage: while
- * it isn't technically a `@Composable` operation, it signals intentional use of Compose state
- * (often kept `@Composable` for a tighter recomposition scope), so we don't flag it. Invoking a
- * value whose type is a `@Composable` function type (such as a `@Composable () -> Unit` held in a
- * property or local) also counts as composition usage. It can still miss some removable cases,
- * which is the safe direction.
+ * This detector only reports when the body and default argument values do not use composition.
+ * Composable calls, composable property reads, composable function values, and State value access
+ * all count as composition usage. It also skips declarations whose annotation is part of a
+ * contract, such as overrides, overridable members, interface members, and declarations with
+ * composable slot parameters.
  */
 class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScanner {
 
@@ -146,29 +138,25 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
     accept(
       object : AbstractUastVisitor() {
         override fun visitCallExpression(node: UCallExpression): Boolean {
-          if (
-            !usesComposition && (node.resolve().isComposable() || node.invokesComposableLambda())
-          ) {
-            usesComposition = true
-          }
-          return usesComposition
+          return stopIf(node.usesComposition())
         }
 
         // Catches @Composable property reads, e.g. a CompositionLocal's `current`.
         override fun visitSimpleNameReferenceExpression(
           node: USimpleNameReferenceExpression
         ): Boolean {
-          if (!usesComposition && (node.resolve() as? PsiMethod).isComposable()) {
-            usesComposition = true
-          }
-          return usesComposition
+          return stopIf(node.usesComposition())
         }
 
         // Catches reads and writes of a State's `value` (`state.value` / `state.value = ...`).
         override fun visitQualifiedReferenceExpression(
           node: UQualifiedReferenceExpression
         ): Boolean {
-          if (!usesComposition && node.isStateValueAccess(context)) usesComposition = true
+          return stopIf(node.isStateValueAccess(context))
+        }
+
+        private fun stopIf(foundCompositionUsage: Boolean): Boolean {
+          usesComposition = usesComposition || foundCompositionUsage
           return usesComposition
         }
       }
@@ -185,6 +173,12 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
 
   private fun PsiMethod?.isComposable(): Boolean =
     this?.toUElementOfType<UMethod>()?.isComposable == true
+
+  private fun UCallExpression.usesComposition(): Boolean =
+    resolve().isComposable() || invokesComposableLambda()
+
+  private fun USimpleNameReferenceExpression.usesComposition(): Boolean =
+    (resolve() as? PsiMethod).isComposable()
 
   private fun UCallExpression.invokesComposableLambda(): Boolean {
     val callee = (sourcePsi as? KtCallExpression)?.calleeExpression ?: return false

--- a/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
@@ -146,7 +146,9 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
     accept(
       object : AbstractUastVisitor() {
         override fun visitCallExpression(node: UCallExpression): Boolean {
-          if (!usesComposition && (node.resolve().isComposable() || node.invokesComposableLambda())) {
+          if (
+            !usesComposition && (node.resolve().isComposable() || node.invokesComposableLambda())
+          ) {
             usesComposition = true
           }
           return usesComposition

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtParameter
@@ -223,6 +224,13 @@ fun UParameter.isSlotParameter(): Boolean {
 private fun KtTypeReference.isTypeAlias(): Boolean {
   return (typeElement as? KtUserType)?.referenceExpression?.references?.firstOrNull()?.resolve() is
     KtTypeAlias
+}
+
+fun KtExpression.isComposableFunctionType(): Boolean {
+  return analyze(this) {
+    val type = expressionType?.fullyExpandedType ?: return@analyze false
+    type is KaFunctionType && ComposableClassId in type.annotations
+  }
 }
 
 val KtCallableDeclaration.isModifierReceiver: Boolean

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
@@ -5,10 +5,10 @@ package slack.lint.compose.util
 
 import com.android.tools.lint.client.api.JavaEvaluator
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
-import org.jetbrains.kotlin.analysis.api.components.fullyExpandedType
-import org.jetbrains.kotlin.analysis.api.symbols.symbol
 import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
+import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -212,10 +212,7 @@ fun UParameter.isSlotParameter(): Boolean {
 
   return if (typeRef.isTypeAlias()) {
     // If it's a typealias, fall through to a more thorough check
-    analyze(ktParam) {
-      val type = ktParam.symbol.returnType.fullyExpandedType
-      type is KaFunctionType && ComposableClassId in type.annotations
-    }
+    analyze(ktParam) { isComposableFunctionType(ktParam.symbol.returnType) }
   } else {
     false
   }
@@ -226,12 +223,18 @@ private fun KtTypeReference.isTypeAlias(): Boolean {
     KtTypeAlias
 }
 
-fun KtExpression.isComposableFunctionType(): Boolean {
+fun KtExpression.hasComposableFunctionType(): Boolean {
   return analyze(this) {
-    val type = expressionType?.fullyExpandedType ?: return@analyze false
-    type is KaFunctionType && ComposableClassId in type.annotations
+    val type = expressionType ?: return@analyze false
+    isComposableFunctionType(type)
   }
 }
+
+private fun KaSession.isComposableFunctionType(type: KaType): Boolean {
+  val expandedType = type.fullyExpandedType
+  return expandedType is KaFunctionType && ComposableClassId in expandedType.annotations
+}
+
 
 val KtCallableDeclaration.isModifierReceiver: Boolean
   get() = ModifierNames.contains(receiverTypeReference?.text)

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
@@ -235,7 +235,6 @@ private fun KaSession.isComposableFunctionType(type: KaType): Boolean {
   return expandedType is KaFunctionType && ComposableClassId in expandedType.annotations
 }
 
-
 val KtCallableDeclaration.isModifierReceiver: Boolean
   get() = ModifierNames.contains(receiverTypeReference?.text)
 

--- a/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
@@ -244,4 +244,28 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
         .trimIndent()
     lint().files(stubs, kotlin(code)).run().expectClean()
   }
+
+  @Test
+  fun `no errors when invoking a composable lambda stored in a property`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      sealed interface State {
+        data object A : State
+        class B(val composable: @Composable () -> Unit) : State
+      }
+
+      @Composable
+      fun HandleState(state: State) {
+        when (state) {
+          State.A -> Unit
+          is State.B -> state.composable()
+        }
+      }
+      """
+        .trimIndent()
+    lint().files(stubs, kotlin(code)).run().expectClean()
+  }
 }


### PR DESCRIPTION
`ComposeRedundantComposable` incorrectly flags a `@Composable` function as redundant
when its only use of the composition is invoking a value whose type is a `@Composable`
function type (e.g. a `@Composable () -> Unit` stored in a property/field), rather than
calling a `@Composable`-annotated function or reading a `@Composable` property.

### To Reproduce:
```kotlin
sealed interface MessageViewState {
    data object Hidden : MessageViewState
    class Showing(val composable: @Composable () -> Unit) : MessageViewState
}

@Composable
fun MessageDisplay(state: MessageViewState) {
    when (state) {
        MessageViewState.Hidden -> Unit
        is MessageViewState.Showing -> state.composable() 
    }
}
```

Fixes #568 