### PR TITLE
Fix ComposeRedundantComposable false positive for binary @Composable callees

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
@@ -28,6 +28,7 @@ import org.jetbrains.uast.getContainingUClass
 import org.jetbrains.uast.toUElementOfType
 import org.jetbrains.uast.visitor.AbstractUastVisitor
 import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.calleeIsComposable
 import slack.lint.compose.util.hasComposableFunctionType
 import slack.lint.compose.util.isComposable
 import slack.lint.compose.util.slotParameters
@@ -261,11 +262,22 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
     return isCompositionLocalCurrent(context)
   }
 
+  /**
+   * K2-based fallback that reads @Composable from Kotlin metadata via symbol analysis. This covers
+   * binary dependencies where @Composable (AnnotationRetention.BINARY) may not be visible through
+   * the PSI layer used by [PsiMethod.isComposable].
+   */
+  private fun UCallExpression.calleeIsComposableViaK2(): Boolean {
+    val ktCall = sourcePsi as? KtCallExpression ?: return false
+    return ktCall.calleeIsComposable()
+  }
+
   private fun UCallExpression.compositionUsage(context: JavaContext): CompositionUsage {
     val method = resolve()
     return when {
       method.isCompositionLocalCurrent(context) -> CompositionUsage.READ_ONLY
-      method.isComposable() || invokesComposableLambda() -> CompositionUsage.OTHER
+      method.isComposable() || invokesComposableLambda() || calleeIsComposableViaK2() ->
+        CompositionUsage.OTHER
       else -> CompositionUsage.NONE
     }
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
@@ -7,6 +7,8 @@ import com.android.tools.lint.client.api.JavaEvaluator
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
 import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.name.ClassId
@@ -233,6 +235,22 @@ fun KtExpression.hasComposableFunctionType(): Boolean {
 private fun KaSession.isComposableFunctionType(type: KaType): Boolean {
   val expandedType = type.fullyExpandedType
   return expandedType is KaFunctionType && ComposableClassId in expandedType.annotations
+}
+
+/**
+ * Returns true if this call expression invokes a function whose Kotlin symbol is annotated with
+ * @Composable, using K2 analysis to read from Kotlin metadata.
+ *
+ * This is a more reliable check than the PSI-based approach for binary dependencies where
+ * @Composable (which has AnnotationRetention.BINARY) may not be visible through the PSI layer,
+ * e.g. in class files compiled with the Compose compiler plugin.
+ */
+fun KtCallExpression.calleeIsComposable(): Boolean {
+  return analyze(this) {
+    val call = this@calleeIsComposable.resolveToCall()?.singleFunctionCallOrNull()
+      ?: return@analyze false
+    ComposableClassId in call.partiallyAppliedSymbol.symbol.annotations
+  }
 }
 
 val KtCallableDeclaration.isModifierReceiver: Boolean

--- a/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
@@ -337,11 +337,6 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
   // callee is composable.  If that resolution fails for binary-backed PSI
   // elements the rule incorrectly fires on the caller.
   //
-  // Repro observed in practice with Instacart Design System (IDS): functions
-  // such as TopNavigationDefault, ICScaffold.Scaffold, and BaseInputTextField
-  // all come from a pre-compiled AAR, and callers in the app were flagged even
-  // though their @Composable annotation was required.
-
   // Binary stub compiled with @Retention(AnnotationRetention.BINARY) on @Composable, which
   // matches the real androidx.compose.runtime.Composable.  The @Composable annotation is
   // therefore stored in RuntimeInvisibleAnnotations (CLASS retention) in the class file.

--- a/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.compose
 
+import com.android.tools.lint.checks.infrastructure.TestFiles.bytecode
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import org.intellij.lang.annotations.Language
@@ -324,6 +326,182 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
       """
         .trimIndent()
     lint().files(stubs, kotlin(code)).run().expectClean()
+  }
+
+  // ---- Binary-dependency false-positive repro --------------------------------
+  //
+  // When a @Composable function is compiled into a binary (e.g. a library AAR),
+  // the lint test infrastructure provides it as a JAR rather than source.  The
+  // detector resolves the call via PsiMethod → UMethod and then calls
+  // findAnnotation("androidx.compose.runtime.Composable") to decide whether the
+  // callee is composable.  If that resolution fails for binary-backed PSI
+  // elements the rule incorrectly fires on the caller.
+  //
+  // Repro observed in practice with Instacart Design System (IDS): functions
+  // such as TopNavigationDefault, ICScaffold.Scaffold, and BaseInputTextField
+  // all come from a pre-compiled AAR, and callers in the app were flagged even
+  // though their @Composable annotation was required.
+
+  // Binary stub compiled with @Retention(AnnotationRetention.BINARY) on @Composable, which
+  // matches the real androidx.compose.runtime.Composable.  The @Composable annotation is
+  // therefore stored in RuntimeInvisibleAnnotations (CLASS retention) in the class file.
+  // If lint's PSI layer only reads RuntimeVisibleAnnotations (RUNTIME retention) from binaries,
+  // it will fail to find @Composable on binary methods and fire a false positive.
+  //
+  // LibraryComposableWithValueClass takes a @JvmInline value class parameter, causing the
+  // Kotlin compiler to mangle the JVM method name to LibraryComposableWithValueClass-Yj-AmPM.
+  // If lint's resolve() cannot match the Kotlin-level call to the mangled JVM method, it returns
+  // null and isComposable() returns false — another source of false positives.
+  @Suppress("DEPRECATION")
+  private val binaryComposableLibrary =
+    bytecode(
+      "libs/library.jar",
+      kotlin(
+          """
+          package com.example.library
+
+          import androidx.compose.runtime.Composable
+
+          @JvmInline value class LibraryColor(val value: Long)
+
+          @Composable
+          fun LibraryComposable() {}
+
+          @Composable
+          fun LibraryComposableWithValueClass(color: LibraryColor = LibraryColor(0L)) {}
+
+          class LibraryComponent {
+            @Composable
+            fun Render() {}
+          }
+          """
+        )
+        .indented(),
+      // Class files compiled with @Composable having AnnotationRetention.BINARY (matching
+      // real androidx.compose.runtime.Composable). The annotation is stored in
+      // RuntimeInvisibleAnnotations in the class file — lint's PSI layer may not read these
+      // from binary PSI elements, causing false-positive ComposeRedundantComposable reports.
+      """
+      com/example/library/LibraryKt.class:
+      H4sIAAAAAAAC/41RTW/TQBB9a+fDcVvqlo826SelpSkQ3FbcKgRVJNSEFBBF
+      QainjWNgG9sbeZ2qXFD/Blf+AbeKA6o48qMQs44rCpUolnb2zezM88ybHz+/
+      fgPwAPcY5jwZuv4RD/uB7waiE/P4g9sa3k+TIhiDc8APuRvw6J37vHPgexQ1
+      GSaypLoM+1LxTuAzmNW1NsNKi0fdWIrukeulj74bD6JEhL77O3mLYfUCw2uR
+      vG/zYODXA65U7c1BbTt8scuQqzY1cd6TgYwZWJPB/c/i5a7/lg+ChGGq2my0
+      /h5lS/Mu/kODuv5lEVdIBk9GKokHXiLjmqDcYV/NUTiYsDGOyVFYKNkwcE3L
+      05NJICJ31094lyecBjbCQ5N0N7QxtQHN0qP4kdDeOqHuBsPD0+NJ+/TYNhzD
+      Niw60+ldsZzT44qxznaKlbJjaLRpWYZjEsrtFL9/LuSsvFPQJJtMUy9cIhHD
+      UuuyyalrO/Pv90jEXF12adHjLRH5zwZhx49fDVc/83K44kZ0KJSg0HYUyYQn
+      gkRjmGxJjwdtHgudnZWM7SXc6+3yfubbe3IQe/4ToZ1yxte+wIYNUjin1YOJ
+      MvIokL9CXhnDj31Jlb1NtkA3aCurGS6mabSlrOSuXsdZiXGuZARVsqMpps7I
+      x3kSp0RvY4Q1yVk/zmzu4ydYpRNcfTR/gutDzrW0TzbyB7mBO+njctrBY4re
+      oEGm9mE2MN1AuYEKZghitoE5zO+DKSxgcR9FhbzCTYUlBVvhloKlUPoFauQN
+      vdEDAAA=
+      """,
+      """
+      com/example/library/LibraryComponent.class:
+      H4sIAAAAAAAC/41Qy27TQBQ9M06c4KbELa+05SlRxENi0oodDwkqIYwMSAVl
+      k9XEHpVp7JnKdqKwy7fwB6yQWKCIJR+FuON4gWCDJZ975tx75s69P399+w7g
+      EW4x3E5sLtRC5meZEpmeFLL4JOJ1PLL5mTXKVB0whvBUzqXIpDkR7yanKiHV
+      Y/CfaKOrZwze3XujHtrwA7TQYWhVH3XJcCf+nwaP6aJjZVJVMOzH0qSF1elC
+      JC5fKlHMTKVzJer6Uk4yRYateGqrTBvxRlUylZUkjedzjybjDjwHYGBTR2gA
+      vtCODYmlBwxitQwDPuABD1fLgHc9InywWh7yIXvR+fHZb3V56L3uhq1dPmy/
+      6jjbIXM3Bs3zH04rmvPIpoqhH2uj3s7yiSo+uAcybMc2kdlIFtqdG3HveD1K
+      ZOa61CQ9N8ZWstLW0LKC93ZWJOqldqU7Tenon0IcgNOS3cfpObRzwj06CTcu
+      xfb9r+h+qdNXCf1a3MQ1wt66AOcQUNzCBmV5bX5Qb4v+v439P4ysMV5vsr26
+      9kaNu7hJ8Smpm9Tg/BhehH6EMKI22xEu4GKES7g8BitxBYMx/BJBiZ0S7dLx
+      DeK/AU9ugNubAgAA
+      """,
+      """
+      com/example/library/LibraryColor.class:
+      H4sIAAAAAAAC/4VUXVMbVRh+zsluslkW2ISPEqgptLZNKDRAVay0QEFrE0Nb
+      oUYpfswSdmAh2cXshsE7HC/0B3ScsZe98YbO2BkFxs44iHf+JsfxPZsFYoh2
+      JnPej30/nvO878mff//6G4A38AVDf9EpZ8xto7xZMjMla7liVL7K5Gty1ik5
+      lQgYg75ubBmZkmGvZh4sr5tFL4IQg7JqegWjVDUZQql0jkHeqlkspyECJQqO
+      KIPkrVkuw8X8q1pNMLR6zoJXsezVYYvCGLpSuXT+tHntG8Wda/TNVK3Siklo
+      2xnCtyzb8iZ9VAUNMcRV6Ohg6KjvlvLB3lbQRRnG5qZprzAMp852OwsgaDah
+      4Rx6RO0Ew/lmSOsD+0TgeRE4+/+BSRF4geg95oKhM9WEBQ0DuChiLxHHRmV1
+      REMr2lQi/QoRuWa4a7POihkQKRG8LEPbaZW8Y69GMEh9jkM1DCGt4hqGfeqy
+      GlLC5hhhaDG/rBolN6jWncrlG1diIv2YQa3ay862H6XRgoVF9pu0GI63ZlYY
+      4meziPxaaTHsZkU1jOGGqDNRu0VBhSSGqRcd2/Uq1aLnVOouSWuoHENguCym
+      8sq9EztyW7SYpd3dYtDqLkt3l1O5nLgc3xwVxxjdP7/heCXLzqxvlTO5rXLW
+      JsMkgLHjD3OmZ6wYnkE+Xt4K0XPj4giJA9RlQyj0svi2JTTqwleo+ovDnUGV
+      93CV64c7Kv24HlW5IpNsISmRVEiGSLaR5MrRt9M9hztjfITNtMfDOu/lI6Gj
+      Z2FJkXQ516crZEfHFF3tlXrYCLv3x/dH30j+9xZdy8X0VvreJrxf17ztuk7e
+      GHnjdd4OvXM+dlJbIVy9khLWI0ffMS6AEyN0JzXg9PqGR6MQC8XQnide7lfL
+      y2blkbFcMsUKOEWjVDAqlrADZ+uCZxQ35ozNwFYXnGqlaN61hJGYr9qeVTYL
+      lmvR1zu27XiGZ9H0MUozk3xC4+IPhzQxShlh8iySlaHvhA3y4M9Qn4sh4DGd
+      4ZoTS35CTW8hDYiKJxQkjyNE8UDiJfTFfXTGu/fQm9zDa3p6D/17eP0nv/Np
+      kQQu+xiYeJhBkSsBAkUgOMDVxhzlpDG9tSDnEuWIxnLyANd3GxLkkyZDdL2m
+      TUZ3/7MJPaUg5yERJ5PsG/od/Cnk0O7QIfge3ppJDjz5QdjSrk/Yp3RGwKN/
+      oV3ya3b74PoCHEIbx9s+gpt4J6g+GnAXFYiuHeDWKaRaejSAJDSRznQuHmGQ
+      Pknp4lmog/uYHLzwC9QXTYdXq6We1FL9LWBUcwrTQa3+gE2efN5AC6/tjJ7A
+      HcwE0VeJFh/fS/DF5D7ebRxYFO/5STHx91Y3sH+tGWuyWgncxftBwhR1EXur
+      JfufPEVE+hFS6JRtGVydridLw72Aaw1Z0sSFPvPDP8HnJG3SciQ/oNT8EkJZ
+      zGVxP4sHeJjFh5jPYgGPlsBcfITCErpcaC4+dhHxzykX0y5kF2EXN33PuIsx
+      FzdcDPlmykXaxYCvt7po+wcGa27RQAgAAA==
+      """,
+      """
+      META-INF/main.kotlin_module:
+      H4sIAAAAAAAC/2NgYGBmYGBgYoDQYMClwCWcnJ+rl1qRmFuQk6qXk5lUlFhU
+      KcTpA2F4lygxaDEAAD+nAj06AAAA
+      """,
+    )
+
+  @Test
+  fun `no errors when calling a top-level composable from a binary dependency`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import com.example.library.LibraryComposable
+
+      @Composable
+      fun Caller() {
+        LibraryComposable()
+      }
+      """
+        .trimIndent()
+    lint().files(stubs, binaryComposableLibrary, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `no errors when calling a member composable from a binary dependency`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import com.example.library.LibraryComponent
+
+      @Composable
+      fun Caller(component: LibraryComponent) {
+        component.Render()
+      }
+      """
+        .trimIndent()
+    lint().files(stubs, binaryComposableLibrary, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `no errors when calling a binary composable whose JVM name is mangled by a value class parameter`() {
+    // LibraryComposableWithValueClass takes a @JvmInline value class (LibraryColor), so the
+    // Kotlin compiler mangles its JVM method name to LibraryComposableWithValueClass-Yj-AmPM.
+    // If lint's resolve() matches the Kotlin-level call to the mangled JVM method and can still
+    // see @Composable on it, no false positive should fire.
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import com.example.library.LibraryColor
+      import com.example.library.LibraryComposableWithValueClass
+
+      @Composable
+      fun Caller() {
+        LibraryComposableWithValueClass(color = LibraryColor(0L))
+      }
+      """
+        .trimIndent()
+    lint().files(stubs, binaryComposableLibrary, kotlin(code)).run().expectClean()
   }
 
   @Test


### PR DESCRIPTION
## Summary

`ComposeRedundantComposable` encounters false-positive warnings on `@Composable` functions that call other `@Composable` functions from a pre-compiled AAR binary.

The root cause: `@Composable` has `AnnotationRetention.BINARY`, meaning it's stored as `RuntimeInvisibleAnnotations` in class files. The PSI-based `findAnnotation()` path may fail to see it for binary dependencies compiled with the Compose compiler plugin (which also transforms function signatures), causing the detector to conclude the function doesn't use composition.

### Changes

`RedundantComposableDetector` now has a K2-based fallback (`calleeIsComposableViaK2`) alongside the existing PSI check. It resolves the call to its Kotlin symbol via `analyze {}` and checks for `@Composable` through `KaAnnotationList`, which reads from Kotlin metadata rather than class-file annotations.