### PR TITLE
Added `ComposeItemKeyNotSaveable` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 **Unreleased**
 --------------
 
+- **New**: Add `ComposeItemKeyNotSaveable` to flag `key` values in `Lazy*` layout builders whose type can't be saved to a `Bundle` on Android.
 - **Enhancement**: Suggest just annotating with `@ReadOnlyComposable` if a function is only `@Composable` to access composition locals.
 - **Fix**: Fix false positive in `ComposeRedundantComposable` when invoking composable function parameters in the body.
 

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ComposeLintsIssueRegistry.kt
@@ -28,6 +28,7 @@ class ComposeLintsIssueRegistry : IssueRegistry() {
       *CompositionLocalUsageDetector.ISSUES,
       ContentEmitterReturningValuesDetector.ISSUE,
       ItemKeyHashCodeDetector.ISSUE,
+      ItemKeyNotSaveableDetector.ISSUE,
       ModifierMissingDetector.ISSUE,
       ModifierReusedDetector.ISSUE,
       ModifierWithoutDefaultDetector.ISSUE,

--- a/compose-lint-checks/src/main/java/slack/lint/compose/ItemKeyNotSaveableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ItemKeyNotSaveableDetector.kt
@@ -1,0 +1,187 @@
+// Copyright (C) 2026 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import com.intellij.psi.CommonClassNames
+import com.intellij.psi.PsiArrayType
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiPrimitiveType
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypeParameter
+import org.jetbrains.uast.UBlockExpression
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.ULambdaExpression
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UReturnExpression
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+import slack.lint.compose.ItemKeyNotSaveableDetector.Companion.RESTRICTED_SCOPES
+import slack.lint.compose.ItemKeyNotSaveableDetector.Companion.SAVEABLE_TYPES
+import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.allSupertypes
+import slack.lint.compose.util.isFunctionalInterface
+import slack.lint.compose.util.sourceImplementation
+
+/**
+ * Flags lazy-layout `key` values whose type can't be saved to a `Bundle`. Item keys are persisted
+ * across configuration changes and process death, so on Android they must be a primitive,
+ * `String`/`CharSequence`, `Serializable`, or `Parcelable`; anything else crashes at runtime once
+ * the key is saved and restored.
+ *
+ * Scoping is by receiver type (see [RESTRICTED_SCOPES]), which uniformly covers interface members
+ * (`item`, `items(count, ...)`) and extensions (`items(List)`, `itemsIndexed`) without firing on
+ * unrelated APIs that happen to take a `key`. The `key` argument is found via parameter mapping (so
+ * named/positional/reordered all work), then its type is checked in [isSaveable] - conservatively,
+ * reporting only types that provably aren't saveable.
+ */
+class ItemKeyNotSaveableDetector : ComposableFunctionDetector(), SourceCodeScanner {
+  companion object {
+    /**
+     * Receiver types whose `key` carries the "must be saveable via `Bundle`" restriction; a call is
+     * checked only when invoked on one of these (or a subtype). Sourced from every AndroidX scope
+     * documenting that restriction; extensions (paging, Wear `expandable*`) are covered
+     * transitively via the shared receiver. Pager is intentionally absent - it has no restriction.
+     */
+    private val RESTRICTED_SCOPES =
+      setOf(
+        "androidx.compose.foundation.lazy.LazyListScope",
+        "androidx.compose.foundation.lazy.grid.LazyGridScope",
+        "androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope",
+        "androidx.wear.compose.foundation.lazy.ScalingLazyListScope",
+        "androidx.wear.compose.foundation.lazy.TransformingLazyColumnScope",
+        "androidx.wear.compose.material.ScalingLazyListScope", // deprecated material variant
+        "androidx.xr.glimmer.list.GlimmerLazyListScope",
+      )
+
+    private val SAVEABLE_TYPES =
+      setOf(
+        "android.os.Bundle",
+        "android.os.IBinder",
+        "android.os.Parcelable",
+        "android.util.Size",
+        "android.util.SizeF",
+        "android.util.SparseArray",
+        "java.io.Serializable",
+        "java.lang.CharSequence",
+
+        // These are included even though their static type isn't Serializable, because stdlib
+        // factories (listOf/mapOf/...) return Serializable impls. Flagging them would give a
+        // false-positive on the common "composite key built from a list" pattern
+        "java.util.Collection",
+        "java.util.Map",
+        "kotlin.collections.Collection",
+        "kotlin.collections.Map",
+      )
+
+    val ISSUE =
+      Issue.create(
+        id = "ComposeItemKeyNotSaveable",
+        briefDescription = "Item key type must be saveable in a Bundle",
+        explanation =
+          issueText(
+            """
+            Item keys in `Lazy*` layouts can be persisted across configuration changes and process
+            death, so on Android the type of the key should be saveable via `Bundle`: a primitive,
+            `String`/`CharSequence`, `Serializable`, or `Parcelable`. A key whose type is none of
+            these can crash at runtime when the key is saved and restored (e.g. when item state is
+            stored via `rememberSaveable`).
+
+            Use a saveable identifier instead (e.g. a `String` or `Int` id), or make the key type
+            `Parcelable`/`Serializable`.
+
+            See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information.
+            """
+          ),
+        category = Category.CORRECTNESS,
+        priority = Priorities.NORMAL,
+        severity = Severity.WARNING,
+        implementation = sourceImplementation<ItemKeyNotSaveableDetector>(),
+      )
+  }
+
+  override fun visitComposable(context: JavaContext, method: UMethod) {
+    method.uastBody?.accept(
+      object : AbstractUastVisitor() {
+        override fun visitMethod(node: UMethod): Boolean = true
+
+        override fun visitCallExpression(node: UCallExpression): Boolean {
+          if (!node.isRestrictedScopeCall()) return false
+          // Resolve the argument bound to the key parameter via the parameter mapping rather than
+          // matching a literal "key =" name, so positionally-passed and reordered keys are covered
+          val method = node.resolve() ?: return false
+          val keyArgument =
+            context.evaluator
+              .computeArgumentMapping(node, method)
+              .entries
+              .firstOrNull { (_, parameter) -> parameter.name == "key" }
+              ?.key ?: return false
+
+          val keyExpression =
+            when (keyArgument) {
+              // The lambda form carries the type on the returned expression
+              is ULambdaExpression -> keyArgument.returnedExpression ?: return false
+              // The direct-value form carries it on the argument itself
+              else -> keyArgument
+            }
+
+          val keyType = keyExpression.getExpressionType() ?: return false
+          if (!keyType.isSaveable()) {
+            context.report(
+              issue = ISSUE,
+              scope = keyExpression,
+              location = context.getLocation(keyExpression),
+              message = ISSUE.getExplanation(TextFormat.TEXT),
+            )
+          }
+          return false
+        }
+      }
+    )
+  }
+
+  /**
+   * Whether this call is invoked on a [RESTRICTED_SCOPES] receiver (or a subtype). Covers both
+   * interface members and extension functions, since both report the scope as the receiver type.
+   */
+  private fun UCallExpression.isRestrictedScopeCall(): Boolean {
+    val receiver = (receiverType as? PsiClassType)?.resolve() ?: return false
+    return receiver.allSupertypes.any { it.qualifiedName in RESTRICTED_SCOPES }
+  }
+
+  /** The expression whose value a lambda returns (its last statement / explicit return). */
+  private val ULambdaExpression.returnedExpression: UExpression?
+    get() {
+      val last = (body as? UBlockExpression)?.expressions?.lastOrNull() ?: return null
+      return if (last is UReturnExpression) last.returnExpression else last
+    }
+
+  /**
+   * Whether [this] type can be persisted to a `Bundle`: a primitive, an array whose component type
+   * is saveable, or a class assignable to one of [SAVEABLE_TYPES]. Collection element types aren't
+   * inspected (not reliably reachable through generics), so `key = { listOf(notSaveable) }` passes.
+   *
+   * Returns true for types it can't analyze, keeping the rule conservative: function types (a
+   * stored selector or reference, where the real key type is out of reach) and `Any`/`Object`
+   * (whose static type says nothing about the runtime value).
+   */
+  private fun PsiType.isSaveable(): Boolean =
+    when (this) {
+      is PsiPrimitiveType -> true
+      is PsiArrayType -> componentType.isSaveable()
+      is PsiClassType -> {
+        val resolved = resolve()
+        resolved == null ||
+          resolved is PsiTypeParameter ||
+          resolved.qualifiedName == CommonClassNames.JAVA_LANG_OBJECT ||
+          resolved.isFunctionalInterface ||
+          resolved.allSupertypes.any { it.qualifiedName in SAVEABLE_TYPES }
+      }
+      else -> true
+    }
+}

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ItemKeyNotSaveableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ItemKeyNotSaveableDetectorTest.kt
@@ -1,0 +1,730 @@
+// Copyright (C) 2026 Salesforce, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.compose
+
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.junit.Test
+
+class ItemKeyNotSaveableDetectorTest : BaseComposeLintTest() {
+  private val lazyStub =
+    kotlin(
+      """
+      package androidx.compose.foundation.lazy
+
+      import androidx.compose.runtime.Composable
+
+      interface LazyItemScope
+
+      interface LazyListScope {
+        fun item(key: Any? = null, content: @Composable LazyItemScope.() -> Unit)
+        fun items(
+          count: Int,
+          key: ((index: Int) -> Any)? = null,
+          itemContent: @Composable LazyItemScope.(index: Int) -> Unit,
+        )
+      }
+
+      fun <T> LazyListScope.items(
+        items: List<T>,
+        key: ((item: T) -> Any)? = null,
+        itemContent: @Composable LazyItemScope.(item: T) -> Unit,
+      ) {}
+
+      fun <T> LazyListScope.itemsIndexed(
+        items: List<T>,
+        key: ((index: Int, item: T) -> Any)? = null,
+        itemContent: @Composable LazyItemScope.(index: Int, item: T) -> Unit,
+      ) {}
+
+      @Composable fun LazyColumn(content: LazyListScope.() -> Unit) {}
+      """
+        .trimIndent()
+    )
+
+  private val pagerStub =
+    kotlin(
+      """
+      package androidx.compose.foundation.pager
+
+      import androidx.compose.runtime.Composable
+
+      interface PagerScope
+
+      @Composable
+      fun HorizontalPager(
+        pageCount: Int,
+        key: ((index: Int) -> Any)? = null,
+        pageContent: @Composable PagerScope.(page: Int) -> Unit,
+      ) {}
+      """
+        .trimIndent()
+    )
+
+  private val gridStub =
+    kotlin(
+      """
+      package androidx.compose.foundation.lazy.grid
+
+      import androidx.compose.runtime.Composable
+
+      interface LazyGridItemScope
+
+      interface LazyGridScope {
+        fun item(key: Any? = null, content: @Composable LazyGridItemScope.() -> Unit)
+      }
+
+      fun <T> LazyGridScope.items(
+        items: List<T>,
+        key: ((item: T) -> Any)? = null,
+        itemContent: @Composable LazyGridItemScope.(item: T) -> Unit,
+      ) {}
+
+      @Composable fun LazyVerticalGrid(content: LazyGridScope.() -> Unit) {}
+      """
+        .trimIndent()
+    )
+
+  private val staggeredGridStub =
+    kotlin(
+      """
+      package androidx.compose.foundation.lazy.staggeredgrid
+
+      import androidx.compose.runtime.Composable
+
+      interface LazyStaggeredGridItemScope
+
+      interface LazyStaggeredGridScope {
+        fun item(key: Any? = null, content: @Composable LazyStaggeredGridItemScope.() -> Unit)
+      }
+
+      fun <T> LazyStaggeredGridScope.items(
+        items: List<T>,
+        key: ((item: T) -> Any)? = null,
+        itemContent: @Composable LazyStaggeredGridItemScope.(item: T) -> Unit,
+      ) {}
+
+      @Composable fun LazyVerticalStaggeredGrid(content: LazyStaggeredGridScope.() -> Unit) {}
+      """
+        .trimIndent()
+    )
+
+  private val parcelableStub =
+    kotlin(
+      """
+      package android.os
+
+      interface Parcelable
+      """
+        .trimIndent()
+    )
+
+  override fun getDetector(): Detector = ItemKeyNotSaveableDetector()
+
+  override fun getIssues(): List<Issue> = listOf(ItemKeyNotSaveableDetector.ISSUE)
+
+  @Test
+  fun `errors when key type is not saveable`() {
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+
+      class NotSaveable(val int: Int)
+
+      @Composable
+      fun Content(list: List<NotSaveable>) {
+        LazyColumn {
+          items(list, key = { it }) {}
+          items(list, key = { NotSaveable(it.int) }) {}
+          item(key = NotSaveable(0)) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/NotSaveable.kt:10: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            items(list, key = { it }) {}
+                                ~~
+        src/NotSaveable.kt:11: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            items(list, key = { NotSaveable(it.int) }) {}
+                                ~~~~~~~~~~~~~~~~~~~
+        src/NotSaveable.kt:12: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            item(key = NotSaveable(0)) {}
+                       ~~~~~~~~~~~~~~
+        0 errors, 3 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `no errors for key params outside LazyListScope`() {
+    // The rule is scoped to LazyListScope receivers. Other APIs that happen to take a `key`
+    // (e.g. Pager composables, or unrelated functions) are left alone for now.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.pager.HorizontalPager
+
+      class NotSaveable(val int: Int)
+
+      // An unrelated function that takes a `key` parameter.
+      fun helper(key: Any?) {}
+
+      @Composable
+      fun Content(list: List<NotSaveable>) {
+        HorizontalPager(pageCount = list.size, key = { list[it] }) {}
+        helper(key = NotSaveable(0))
+      }
+      """
+        .trimIndent()
+    lint().files(*commonStubs, pagerStub, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `errors on other restricted scopes via receiver matching`() {
+    // Receiver-type matching generalizes beyond LazyListScope to every type in RESTRICTED_SCOPES,
+    // e.g. LazyGridScope, without any per-API special casing.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+      import androidx.compose.foundation.lazy.grid.items
+
+      class NotSaveable(val int: Int)
+
+      @Composable
+      fun Content(list: List<NotSaveable>) {
+        LazyVerticalGrid {
+          items(list, key = { it }) {}
+          item(key = NotSaveable(0)) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, gridStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/NotSaveable.kt:10: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            items(list, key = { it }) {}
+                                ~~
+        src/NotSaveable.kt:11: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            item(key = NotSaveable(0)) {}
+                       ~~~~~~~~~~~~~~
+        0 errors, 2 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors on subtypes of a restricted scope`() {
+    // Scope matching walks supertypes, so a custom interface extending a restricted scope
+    // (LazyListScope here) is covered without being listed in RESTRICTED_SCOPES itself.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyListScope
+      import androidx.compose.foundation.lazy.items
+
+      class NotSaveable(val int: Int)
+
+      interface MyLazyScope : LazyListScope
+
+      @Composable fun MyLazyColumn(content: MyLazyScope.() -> Unit) {}
+
+      @Composable
+      fun Content(list: List<NotSaveable>) {
+        MyLazyColumn {
+          items(list, key = { it }) {}
+          item(key = NotSaveable(0)) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/NotSaveable.kt:14: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            items(list, key = { it }) {}
+                                ~~
+        src/NotSaveable.kt:15: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            item(key = NotSaveable(0)) {}
+                       ~~~~~~~~~~~~~~
+        0 errors, 2 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `no errors for an unrelated scope with a key parameter`() {
+    // A custom DSL scope shaped exactly like LazyListScope (a `key` parameter on both a member and
+    // an extension) but not in RESTRICTED_SCOPES. Receiver-type scoping must leave it alone even
+    // though the key values aren't saveable.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      class NotSaveable(val int: Int)
+
+      interface SomeOtherListScope {
+        fun item(key: Any? = null, content: () -> Unit)
+      }
+
+      fun <T> SomeOtherListScope.items(
+        items: List<T>,
+        key: ((item: T) -> Any)? = null,
+        content: (T) -> Unit
+      ) {}
+
+      @Composable fun MyList(content: SomeOtherListScope.() -> Unit) {}
+
+      @Composable
+      fun Content(list: List<NotSaveable>) {
+        MyList {
+          item(key = NotSaveable(0)) {}
+          items(list, key = { it }) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `arrays are saveable only when their component type is`() {
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+
+      class NotSaveable(val int: Int)
+      class Row(val intArray: IntArray, val stringArray: Array<String>, val notSaveableArray: Array<NotSaveable>)
+
+      @Composable
+      fun Content(list: List<Row>) {
+        LazyColumn {
+          items(list, key = { it.intArray }) {}
+          items(list, key = { it.stringArray }) {}
+          items(list, key = { it.notSaveableArray }) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/NotSaveable.kt:13: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            items(list, key = { it.notSaveableArray }) {}
+                                ~~~~~~~~~~~~~~~~~~~
+        0 errors, 1 warning
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `no errors when key type is saveable`() {
+    val code =
+      $$"""
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+      import androidx.compose.foundation.lazy.itemsIndexed
+      import androidx.compose.foundation.pager.HorizontalPager
+
+      data class Item(val string: String)
+
+      class ParcelKey(val int: Int) : android.os.Parcelable
+
+      class SerKey(val int: Int) : java.io.Serializable
+
+      @Composable
+      fun Content(list: List<Item>) {
+        LazyColumn {
+          items(list, key = { it.string }) {}
+          items(list, key = { it.string.length }) {}
+          items(list, key = { "${it.string}-row" }) {}
+          itemsIndexed(list, key = { index, _ -> index }) { _, _ -> }
+          items(list, key = { ParcelKey(it.string.length) }) {}
+          items(list, key = { SerKey(it.string.length) }) {}
+          item(key = "header") {}
+          // A statically `Any`-typed key isn't provably unsaveable, so it's left alone.
+          items(list, key = { it.string as Any }) {}
+          items(list) {}
+        }
+        HorizontalPager(pageCount = list.size, key = { list[it].string }) {}
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, pagerStub, parcelableStub, kotlin(code))
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `no errors when key type is lambda returning valid type`() {
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+
+      data class Item(val string: String)
+
+      @Composable
+      fun Content(list: List<Item>) {
+        val getKey: (index: Int) -> Any = { index }
+
+        LazyColumn {
+          items(list, key = getKey) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, pagerStub, parcelableStub, kotlin(code))
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `no errors for stdlib types that are serializable`() {
+    // Common key types people reach for. All of enum, Pair/Triple, and List/Set are Serializable in
+    // the stdlib, so resolving their supertypes must keep these clean. If any of these resolve
+    // without their java.io.Serializable supertype the rule would fire on extremely common code.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+
+      enum class Kind { A, B }
+
+      data class Item(val string: String, val kind: Kind)
+
+      @Composable
+      fun Content(list: List<Item>) {
+        LazyColumn {
+          items(list, key = { it.kind }) {}
+          items(list, key = { it.string to it.kind }) {}
+          items(list, key = { Triple(it.string, it.kind, 0) }) {}
+          items(list, key = { listOf(it.string) }) {}
+          items(list, key = { setOf(it.string) }) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint().files(*commonStubs, lazyStub, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `errors when key type is a plain data class`() {
+    // The most common real trigger: a composite key built from a data class, which is NOT
+    // Serializable/Parcelable by default.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+
+      data class Item(val int: Int, val string: String)
+      data class CompositeKey(val int: Int, val string: String)
+
+      @Composable
+      fun Content(list: List<Item>) {
+        LazyColumn {
+          items(list, key = { CompositeKey(it.int, it.string) }) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/Item.kt:11: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            items(list, key = { CompositeKey(it.int, it.string) }) {}
+                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        0 errors, 1 warning
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `positional key arguments are detected`() {
+    // The key argument is resolved via parameter mapping, not by matching a literal `key =` name,
+    // so
+    // a key passed positionally is detected too.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+
+      class NotSaveable(val int: Int)
+
+      @Composable
+      fun Content() {
+        LazyColumn {
+          item(NotSaveable(0)) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/NotSaveable.kt:9: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            item(NotSaveable(0)) {}
+                 ~~~~~~~~~~~~~~
+        0 errors, 1 warning
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `no errors outside a composable context`() {
+    val code =
+      """
+      class NotSaveable(val int: Int)
+
+      // A non-composable function with a `key` parameter shouldn't be flagged.
+      fun helper(key: Any?) {}
+
+      fun notComposable() {
+        helper(key = NotSaveable(0))
+      }
+      """
+        .trimIndent()
+    lint().files(*commonStubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `no errors when key type is a type parameter`() {
+    // Generics are deliberately left alone: a key whose static type is a bare type parameter isn't
+    // provably unsaveable, so the conservative contract is to stay quiet even when the eventual
+    // runtime type might not be saveable.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyListScope
+      import androidx.compose.foundation.lazy.items
+
+      @Composable
+      fun <T> Content(list: List<T>, keySelector: (T) -> T, content: LazyListScope.() -> Unit) {
+        content {
+          items(list, key = { keySelector(it) }) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint().files(*commonStubs, lazyStub, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `errors when a multi-statement key lambda returns an unsaveable type`() {
+    // The key argument can be a block lambda with intermediate statements; the type is read off the
+    // returned expression, not the whole block.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+
+      data class Item(val int: Int)
+      data class CompositeKey(val int: Int)
+
+      @Composable
+      fun Content(list: List<Item>) {
+        LazyColumn {
+          items(list, key = {
+            val id = it.int
+            CompositeKey(id)
+          }) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/Item.kt:13: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+              CompositeKey(id)
+              ~~~~~~~~~~~~~~~~
+        0 errors, 1 warning
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors on itemsIndexed with an unsaveable key`() {
+    // itemsIndexed has a two-parameter key lambda; the returned expression is still inspected.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.itemsIndexed
+
+      class NotSaveable(val int: Int)
+
+      @Composable
+      fun Content(list: List<NotSaveable>) {
+        LazyColumn {
+          itemsIndexed(list, key = { _, item -> item }) { _, _ -> }
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/NotSaveable.kt:10: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            itemsIndexed(list, key = { _, item -> item }) { _, _ -> }
+                                                  ~~~~
+        0 errors, 1 warning
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `errors on the staggered grid scope`() {
+    // LazyStaggeredGridScope is in RESTRICTED_SCOPES; verify it directly rather than relying solely
+    // on the receiver-matching mechanism proven for LazyListScope/LazyGridScope.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+      import androidx.compose.foundation.lazy.staggeredgrid.items
+
+      class NotSaveable(val int: Int)
+
+      @Composable
+      fun Content(list: List<NotSaveable>) {
+        LazyVerticalStaggeredGrid {
+          items(list, key = { it }) {}
+          item(key = NotSaveable(0)) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, staggeredGridStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/NotSaveable.kt:10: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            items(list, key = { it }) {}
+                                ~~
+        src/NotSaveable.kt:11: Warning: Item keys in Lazy* layouts can be persisted across configuration changes and process death, so on Android the type of the key should be saveable via Bundle: a primitive, String/CharSequence, Serializable, or Parcelable. A key whose type is none of these can crash at runtime when the key is saved and restored (e.g. when item state is stored via rememberSaveable).
+
+        Use a saveable identifier instead (e.g. a String or Int id), or make the key type Parcelable/Serializable.
+
+        See https://slackhq.github.io/compose-lints/rules/#item-key-types-must-be-saveable for more information. [ComposeItemKeyNotSaveable]
+            item(key = NotSaveable(0)) {}
+                       ~~~~~~~~~~~~~~
+        0 errors, 2 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `no errors when key type is a nullable saveable type`() {
+    // Nullability shouldn't break supertype resolution: a nullable String key is still saveable.
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+
+      data class Item(val string: String?)
+
+      @Composable
+      fun Content(list: List<Item>) {
+        LazyColumn {
+          items(list, key = { it.string }) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint().files(*commonStubs, lazyStub, kotlin(code)).run().expectClean()
+  }
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -478,3 +478,32 @@ LazyColumn {
 If you truly need an identity-based key and aren't targeting Kotlin Multiplatform, `java.lang.System.identityHashCode` is allowed.
 
 Related rule: [`ComposeItemKeyHashCode`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ItemKeyHashCodeDetector.kt)
+
+### Item key types must be saveable
+
+`Lazy*` layouts can persist the current `key` across configuration changes and process death (for example to restore item state stored via `rememberSaveable`). On Android that state is stored in a `Bundle`, so [the type of the key should be saveable via `Bundle`](https://developer.android.com/develop/ui/compose/lists#item-keys) - a primitive, `String`/`CharSequence`, `Serializable`, or `Parcelable`. A key whose type is none of these can crash at runtime when the key is saved and restored.
+
+So this rule flags `key` values whose type isn't saveable in lazy-layout builders (`item`, `items`, `itemsIndexed`, including extensions):
+
+```kotlin
+class CompositeKey(val a: Int, val b: String)
+
+// Don't do this: CompositeKey can't be put in a Bundle
+LazyColumn {
+    items(people, key = { CompositeKey(it.groupId, it.id) }) { /* ... */ }
+}
+
+// Do this instead: use a saveable identifier
+LazyColumn {
+    items(people, key = { "${it.groupId}-${it.id}" }) { /* ... */ }
+}
+
+// ...or make the key type Parcelable/Serializable
+@Parcelize data class CompositeKey(val a: Int, val b: String) : Parcelable
+```
+
+Scoping is by receiver type. A call is only checked when it's invoked on one of the AndroidX scopes that documents this restriction (or a subtype): `LazyListScope`, `LazyGridScope`, `LazyStaggeredGridScope`, the Wear `ScalingLazyListScope`/`TransformingLazyColumnScope`, and Glimmer's `GlimmerLazyListScope`. Both interface members and extension functions are covered, while unrelated APIs that happen to take a `key` (e.g. `Pager`) are not.
+
+The check is conservative: it only fires when the key's type resolves to a concrete class that is provably not saveable. Arrays are checked by their component type, but unresolved types, type parameters (generics), `Any`, function-typed `key` selectors, and collections (whose stdlib implementations are always `Serializable`) are left alone. The `key` argument is resolved by parameter mapping, so it's caught whether passed by name or positionally.
+
+Related rule: [`ComposeItemKeyNotSaveable`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ItemKeyNotSaveableDetector.kt)


### PR DESCRIPTION
This adds a new rule that flags item `key` values in lazy layouts (`LazyColumn`, `LazyVerticalGrid`, staggered grids, Wear lazy lists, etc.) when the key type must be saveable into a `Bundle`, but the parameter type is only `Any` (and therefore has no compiler-driven type checking. For reference, the target scopes for this rule was [driven primarily by this search](https://cs.android.com/search?q=%22should%20be%20saveable%20via%20Bundle%22&sq=) on cs.android.com. Until now I've been maintaining very a basic custom rule on this, but I figured it'd be better in a proper project.

On Android the `key` type needs to be a primitive, `Serializable`, `Parcelable` or [one of a few other types](https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/os/Bundle.java;l=481-529?q=bundle.java). If the key is something else (e.g. a data class), the app will crash at runtime. I've been tripped up a few times by this in various projects, thought it'd be useful as a CI check.

I've been a bit eager with the amount of tests - can always strip some back if you'd prefer.

Just in case it needs declaring anywhere, a lot of this was :robot: AI-assisted :robot: