### PR TITLE
Improve redundant composable detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '23'
+          java-version: '26'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '23'
+          java-version: '26'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- **Enhancement**: Add an `ignore-annotated` option to `ComposeRedundantComposable` as an escape hatch for this check, which can be useful for scenarios where a codebase may generate other contracts based on a composable declaration.
+- **Fix**: Fix false positives in `ComposeRedundantComposable` for nullable composable slots and delegated Compose `State` reads.
 - **Fix**: Fix false positives in `ComposeRedundantComposable` when reading composable properties such as `CompositionLocal.current` in commonMain code.
 
 1.5.3

--- a/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt
@@ -9,9 +9,13 @@ import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.Location
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.StringOption
 import com.android.tools.lint.detector.api.TextFormat
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypes
 import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.resolveToCall
 import org.jetbrains.kotlin.analysis.api.resolution.KaSimpleVariableAccess
@@ -26,6 +30,9 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.psi.psiUtil.isTopLevelKtOrJavaMember
 import org.jetbrains.uast.UAnnotation
@@ -37,6 +44,7 @@ import org.jetbrains.uast.USimpleNameReferenceExpression
 import org.jetbrains.uast.getContainingUClass
 import org.jetbrains.uast.visitor.AbstractUastVisitor
 import slack.lint.compose.util.Priorities
+import slack.lint.compose.util.StringSetLintOption
 import slack.lint.compose.util.hasComposableFunctionType
 import slack.lint.compose.util.isComposableCall
 import slack.lint.compose.util.isComposableMethod
@@ -55,7 +63,11 @@ import slack.lint.compose.util.sourceImplementation
  * of a contract, such as overrides, overridable members, interface members, and declarations with
  * composable slot parameters.
  */
-class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScanner {
+class RedundantComposableDetector
+@JvmOverloads
+constructor(
+  private val ignoredAnnotations: StringSetLintOption = StringSetLintOption(IGNORE_ANNOTATED)
+) : ComposableFunctionDetector(ignoredAnnotations to ISSUE), SourceCodeScanner {
 
   companion object {
     private const val COMPOSABLE = "androidx.compose.runtime.Composable"
@@ -65,13 +77,21 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
     private val COMPOSABLE_CLASS_ID = ClassId.topLevel(FqName(COMPOSABLE))
     private val READ_ONLY_COMPOSABLE_CLASS_ID = ClassId.topLevel(FqName(READ_ONLY_COMPOSABLE))
 
+    internal val IGNORE_ANNOTATED =
+      StringOption(
+        "ignore-annotated",
+        "A comma-separated list of fully qualified annotations on composables to ignore.",
+        null,
+        "Annotations on an object only ignore its Unit-returning composable operator invoke entry point.",
+      )
+
     val ISSUE =
       Issue.create(
-        id = "ComposeRedundantComposable",
-        briefDescription = "Unnecessary @Composable annotation",
-        explanation =
-          issueText(
-            """
+          id = "ComposeRedundantComposable",
+          briefDescription = "Unnecessary @Composable annotation",
+          explanation =
+            issueText(
+              """
             This declaration is annotated with `@Composable` but doesn't call any other
             `@Composable` functions or read any `@Composable` properties (like a
             `CompositionLocal`'s `current`), so it doesn't use the composition and the
@@ -79,12 +99,13 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
 
             See https://slackhq.github.io/compose-lints/rules/#remove-unnecessary-composable-annotations for more information.
             """
-          ),
-        category = Category.PRODUCTIVITY,
-        priority = Priorities.NORMAL,
-        severity = Severity.WARNING,
-        implementation = sourceImplementation<RedundantComposableDetector>(),
-      )
+            ),
+          category = Category.PRODUCTIVITY,
+          priority = Priorities.NORMAL,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<RedundantComposableDetector>(),
+        )
+        .setOptions(listOf(IGNORE_ANNOTATED))
 
     val READ_ONLY_ISSUE =
       Issue.create(
@@ -135,13 +156,15 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
     val location = annotation?.let(context::getLocation) ?: context.getNameLocation(method)
     when (bodyUsage) {
       CompositionUsage.NONE ->
-        context.report(
-          ISSUE,
-          annotation ?: method,
-          location,
-          ISSUE.getExplanation(TextFormat.TEXT),
-          annotation?.let { buildRemoveFix(context, it) },
-        )
+        if (!method.hasIgnoredAnnotation()) {
+          context.report(
+            ISSUE,
+            annotation ?: method,
+            location,
+            ISSUE.getExplanation(TextFormat.TEXT),
+            annotation?.let { buildRemoveFix(context, it) },
+          )
+        }
       CompositionUsage.READ_ONLY ->
         if (!method.hasAnnotation(READ_ONLY_COMPOSABLE)) {
           context.report(
@@ -154,6 +177,21 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
         }
       CompositionUsage.OTHER -> return
     }
+  }
+
+  /** Whether this declaration is explicitly excluded from the redundant-composable issue. */
+  private fun UMethod.hasIgnoredAnnotation(): Boolean {
+    if (ignoredAnnotations.value.any { hasAnnotation(it) }) return true
+
+    val containingClass = getContainingUClass() ?: return false // Only members have a container.
+    return name == "invoke" && // Only match the object's invocation entry point.
+      returnType == PsiTypes.voidType() && // Exclude Unit-returning functions only.
+      // Require an actual operator, not just a function named invoke.
+      (sourcePsi as? KtNamedFunction)?.hasModifier(KtTokens.OPERATOR_KEYWORD) == true &&
+      containingClass.sourcePsi is KtObjectDeclaration && // Classes do not qualify.
+      ignoredAnnotations.value.any { // The object itself must have an ignored annotation.
+        containingClass.findAnnotation(it) != null
+      }
   }
 
   /** Quickfix that removes the redundant `@Composable` annotation (and its trailing whitespace). */
@@ -248,8 +286,30 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
   /** Whether [this] is an access (read or write) of a Compose [State]'s `value` property. */
   private fun UQualifiedReferenceExpression.isStateValueAccess(context: JavaContext): Boolean {
     if ((selector as? USimpleNameReferenceExpression)?.identifier != "value") return false
-    val receiverClass = context.evaluator.getTypeClass(receiver.getExpressionType()) ?: return false
+    return receiver.getExpressionType().isComposeState(context)
+  }
+
+  private fun PsiType?.isComposeState(context: JavaContext): Boolean {
+    val receiverClass = context.evaluator.getTypeClass(this) ?: return false
     return context.evaluator.implementsInterface(receiverClass, STATE, /* strict= */ false)
+  }
+
+  /**
+   * Detect delegated reads without matching unrelated operators that happen to be named getValue.
+   */
+  private fun UCallExpression.isStateDelegateGetValue(context: JavaContext): Boolean {
+    if (methodName != "getValue") return false
+    return sequenceOf(receiver, *valueArguments.toTypedArray()).any {
+      it?.getExpressionType().isComposeState(context)
+    }
+  }
+
+  private fun USimpleNameReferenceExpression.isDelegatedStateRead(context: JavaContext): Boolean {
+    val source = sourcePsi ?: return false
+    val property = PsiTreeUtil.getParentOfType(source, KtProperty::class.java) ?: return false
+    val delegateExpression = property.delegateExpression ?: return false
+    return PsiTreeUtil.isAncestor(delegateExpression, source, /* strict= */ false) &&
+      getExpressionType().isComposeState(context)
   }
 
   private fun PsiMethod?.isCompositionLocalCurrent(context: JavaContext): Boolean {
@@ -274,7 +334,8 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
     val method = resolve()
     return when {
       method.isCompositionLocalCurrent(context) -> CompositionUsage.READ_ONLY
-      isComposableCall || invokesComposableLambda() -> CompositionUsage.OTHER
+      isComposableCall || invokesComposableLambda() || isStateDelegateGetValue(context) ->
+        CompositionUsage.OTHER
       else -> CompositionUsage.NONE
     }
   }
@@ -285,7 +346,7 @@ class RedundantComposableDetector : ComposableFunctionDetector(), SourceCodeScan
     val method = resolve() as? PsiMethod
     return when {
       method.isCompositionLocalCurrent(context, this) -> CompositionUsage.READ_ONLY
-      method.isComposableMethod -> CompositionUsage.OTHER
+      method.isComposableMethod || isDelegatedStateRead(context) -> CompositionUsage.OTHER
       else -> resolvesToComposablePropertyUsage()
     }
   }

--- a/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/util/Composables.kt
@@ -16,10 +16,12 @@ import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeElement
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtUserType
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
@@ -210,8 +212,8 @@ fun UParameter.isSlotParameter(): Boolean {
     return true
   }
 
-  return if (typeRef.isTypeAlias()) {
-    // If it's a typealias, fall through to a more thorough check
+  return if (typeRef.typeElement.unwrapNullableType() is KtFunctionType || typeRef.isTypeAlias()) {
+    // Nullable/parenthesized function types and typealiases require semantic annotation lookup.
     analyze(ktParam) { isComposableFunctionType(ktParam.symbol.returnType) }
   } else {
     false
@@ -219,8 +221,15 @@ fun UParameter.isSlotParameter(): Boolean {
 }
 
 private fun KtTypeReference.isTypeAlias(): Boolean {
-  return (typeElement as? KtUserType)?.referenceExpression?.references?.firstOrNull()?.resolve() is
-    KtTypeAlias
+  return (typeElement.unwrapNullableType() as? KtUserType)
+    ?.referenceExpression
+    ?.references
+    ?.firstOrNull()
+    ?.resolve() is KtTypeAlias
+}
+
+private tailrec fun KtTypeElement?.unwrapNullableType(): KtTypeElement? {
+  return if (this is KtNullableType) innerType.unwrapNullableType() else this
 }
 
 fun KtExpression.hasComposableFunctionType(): Boolean {

--- a/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
@@ -17,6 +17,8 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
       """
       package androidx.compose.runtime
 
+      import kotlin.reflect.KProperty
+
       annotation class Composable
 
       annotation class ReadOnlyComposable
@@ -36,6 +38,8 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
         override var value: T
       }
 
+      operator fun <T> State<T>.getValue(thisObj: Any?, property: KProperty<*>): T = value
+
       fun <T> derivedStateOf(calculation: () -> T): State<T> = error("stub")
 
       @Suppress("ComposeRedundantComposable")
@@ -43,6 +47,23 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
       inline fun <T> remember(key1: Any?, crossinline calculation: () -> T): T = error("stub")
 
       @Composable external fun Text(text: String)
+      """
+        .trimIndent()
+    )
+
+  private val annotationStubs =
+    kotlin(
+      """
+      package example
+
+      @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
+      annotation class MyAnnotation
+
+      @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
+      annotation class MyOtherAnnotation
+
+      @Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE)
+      annotation class NotComposable
       """
         .trimIndent()
     )
@@ -469,6 +490,56 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun `no errors when reading delegated Compose State`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.runtime.MutableState
+      import androidx.compose.runtime.State
+      import androidx.compose.runtime.getValue
+
+      @Composable
+      fun readsState(state: State<Int>) {
+        val value by state
+        println(value)
+      }
+
+      @Composable
+      fun readsMutableState(state: MutableState<Int>) {
+        val value by state
+        println(value)
+      }
+      """
+        .trimIndent()
+
+    lint().files(stubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `ordinary property delegates do not count as Compose State`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import kotlin.reflect.KProperty
+
+      class OrdinaryDelegate {
+        operator fun getValue(thisObj: Any?, property: KProperty<*>): Int = 1
+      }
+
+      @Composable
+      fun readsOrdinaryDelegate(delegate: OrdinaryDelegate) {
+        val value by delegate
+        println(value)
+      }
+      """
+        .trimIndent()
+
+    lint().files(stubs, kotlin(code)).run().expectWarningCount(1)
+  }
+
+  @Test
   fun `no errors for composables that take a composable slot`() {
     @Language("kotlin")
     val code =
@@ -482,6 +553,63 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
       """
         .trimIndent()
     lint().files(stubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `no errors for nullable and parenthesized composable slots`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun nullableSlot(content: (@Composable () -> Unit)?) {
+        println("doesn't even call content")
+      }
+
+      @Composable
+      fun parenthesizedSlot(content: (@Composable () -> Unit)) {
+        println("doesn't even call content")
+      }
+
+      @Composable
+      fun nestedNullableSlot(content: ((@Composable () -> Unit)?)?) {
+        println("doesn't even call content")
+      }
+
+      typealias NullableComposableSlot = (@Composable () -> Unit)?
+
+      @Composable
+      fun nullableTypealiasSlot(content: NullableComposableSlot) {
+        println("doesn't even call content")
+      }
+      """
+        .trimIndent()
+
+    lint().files(stubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `ordinary nullable lambdas and unrelated annotations are not composable slots`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import example.NotComposable
+
+      @Composable
+      fun ordinaryNullableSlot(content: (() -> Unit)?) {
+        println("doesn't even call content")
+      }
+
+      @Composable
+      fun unrelatedAnnotatedSlot(content: (@NotComposable () -> Unit)?) {
+        println("doesn't even call content")
+      }
+      """
+        .trimIndent()
+
+    lint().files(stubs, annotationStubs, kotlin(code)).run().expectWarningCount(2)
   }
 
   @Test
@@ -551,5 +679,191 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
       """
         .trimIndent()
     lint().files(stubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `no errors when reading top-level and member composable properties`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.runtime.Text
+
+      val topLevelContent: Int
+        @Composable get() {
+          Text("top-level")
+          return 1
+        }
+
+      class ContentHolder {
+        val memberContent: Int
+          @Composable get() {
+            Text("member")
+            return 2
+          }
+      }
+
+      @Composable
+      fun readsTopLevelProperty() {
+        println(topLevelContent)
+      }
+
+      @Composable
+      fun readsMemberProperty(holder: ContentHolder) {
+        println(holder.memberContent)
+      }
+      """
+        .trimIndent()
+
+    lint().files(stubs, kotlin(code)).run().expectClean()
+  }
+
+  @Test
+  fun `ordinary property getters do not count as composition usage`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      val ordinaryProperty: Int
+        get() = 1
+
+      @Composable
+      fun readsOrdinaryProperty() {
+        println(ordinaryProperty)
+      }
+      """
+        .trimIndent()
+
+    lint().files(stubs, kotlin(code)).run().expectWarningCount(1)
+  }
+
+  @Test
+  fun `configured annotations only ignore matching redundant composables`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import example.MyAnnotation
+      import example.MyOtherAnnotation
+      import example.NotComposable
+
+      @MyAnnotation
+      @Composable
+      fun annotated() {
+        println("annotated")
+      }
+
+      @MyOtherAnnotation
+      @Composable
+      fun alsoAnnotated() {
+        println("also annotated")
+      }
+
+      @NotComposable
+      @Composable
+      fun unconfigured() {
+        println("unconfigured")
+      }
+
+      @Composable
+      fun ordinary() {
+        println("ordinary")
+      }
+
+      @MyAnnotation
+      object AnnotatedEntryPoint {
+        @Composable
+        operator fun invoke() {
+          println("annotated entry point")
+        }
+
+        @Composable
+        fun unrelated() {
+          println("ordinary member")
+        }
+      }
+
+      @MyAnnotation
+      class AnnotatedClass {
+        @Composable
+        operator fun invoke() {
+          println("ordinary class member")
+        }
+      }
+
+      @MyAnnotation
+      object ValueReturningEntryPoint {
+        @Composable
+        operator fun invoke(): String = "ordinary value-returning member"
+      }
+      """
+        .trimIndent()
+
+    val configuration =
+      xml(
+        "lint.xml",
+        """
+        <lint>
+          <issue id="ComposeRedundantComposable">
+            <option
+              name="ignore-annotated"
+              value="example.MyAnnotation,example.MyOtherAnnotation" />
+          </issue>
+        </lint>
+        """
+          .trimIndent(),
+      )
+
+    lint().files(stubs, annotationStubs, kotlin(code), configuration).run().expectWarningCount(5)
+  }
+
+  @Test
+  fun `ignored annotations do not suppress read-only composable suggestions`() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.runtime.CompositionLocal
+      import androidx.compose.runtime.compositionLocalOf
+      import example.MyAnnotation
+
+      val LocalThing: CompositionLocal<Int> = compositionLocalOf { 0 }
+
+      @MyAnnotation
+      @Composable
+      fun readsCompositionLocal() {
+        println(LocalThing.current)
+      }
+      """
+        .trimIndent()
+
+    val configuration =
+      xml(
+        "lint.xml",
+        """
+        <lint>
+          <issue id="ComposeRedundantComposable">
+            <option name="ignore-annotated" value="example.MyAnnotation" />
+          </issue>
+        </lint>
+        """
+          .trimIndent(),
+      )
+
+    lint()
+      .files(stubs, annotationStubs, kotlin(code), configuration)
+      .run()
+      .expect(
+        """
+        src/test.kt:9: Hint: This declaration only uses the composition to read CompositionLocal values, so it can be annotated with @ReadOnlyComposable to avoid generating a group around its body.
+
+        See https://slackhq.github.io/compose-lints/rules/#remove-unnecessary-composable-annotations for more information. [ComposeReadOnlyComposable]
+        @Composable
+        ~~~~~~~~~~~
+        0 errors, 0 warnings, 1 hint
+        """
+          .trimIndent()
+      )
   }
 }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -111,6 +111,17 @@ Removing the redundant annotation drops the unneeded composer plumbing and makes
 !!! note "Library authors"
     A trivially-bodied public composable can be intentionally `@Composable` as part of your API contract; removing it would be a source/binary-incompatible change. Suppress or disable this rule for such declarations.
 
+!!! note "Configuration"
+    The `ignore-annotated` option provides an escape hatch for this check, which can be useful when a codebase generates other contracts based on a composable declaration. Specify a comma-separated list of fully qualified annotation names in `lint.xml`:
+
+    ```xml
+    <issue id="ComposeRedundantComposable">
+       <option
+          name="ignore-annotated"
+          value="example.MyAnnotation,example.MyOtherAnnotation" />
+    </issue>
+    ```
+
 Related rule: [`ComposeRedundantComposable`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/RedundantComposableDetector.kt)
 
 ### Do not emit content and return a result

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.4.10"
-jdk = "23"
+jdk = "26"
 jvmTarget = "17"
 lint = "32.2.1"
 lint-latest = "32.3.1"


### PR DESCRIPTION
Adds an ignore-annotated escape hatch and fixes false positives for nullable composable slots and delegated State reads.