### PR TITLE
Add testDocumentationExample to all lint rule test suites

### DIFF
--- a/compose-lint-checks/src/test/java/slack/lint/compose/CompositionLocalUsageDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/CompositionLocalUsageDetectorTest.kt
@@ -6,6 +6,7 @@ package slack.lint.compose
 import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 class CompositionLocalUsageDetectorTest : BaseComposeLintTest() {
@@ -17,6 +18,37 @@ class CompositionLocalUsageDetectorTest : BaseComposeLintTest() {
   override fun lint(): TestLintTask {
     return super.lint()
       .configureOption(CompositionLocalUsageDetector.ALLOW_LIST, "LocalBanana,LocalPotato")
+  }
+
+  @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      val LocalApple = staticCompositionLocalOf<String> { "Apple" }
+      val LocalPrune = compositionLocalOf { "Prune" }
+      """
+        .trimIndent()
+    lint()
+      .files(kotlin(code))
+      .allowCompilationErrors()
+      .run()
+      .expect(
+        """
+        src/test.kt:1: Warning: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+
+        See https://slackhq.github.io/compose-lints/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
+        val LocalApple = staticCompositionLocalOf<String> { "Apple" }
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test.kt:2: Warning: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+
+        See https://slackhq.github.io/compose-lints/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
+        val LocalPrune = compositionLocalOf { "Prune" }
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        0 errors, 2 warnings
+        """
+          .trimIndent()
+      )
   }
 
   @Test

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ContentEmitterReturningValuesDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ContentEmitterReturningValuesDetectorTest.kt
@@ -24,6 +24,43 @@ class ContentEmitterReturningValuesDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Text
+
+      @Composable
+      fun Something(): String {
+          Text("Hi")
+          Text("Hola")
+          Something2()
+          return "hi"
+      }
+      @Composable
+      fun Something2() {
+          Text("Alo")
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:5: Error: Composable functions should either emit content into the composition or return a value, but not both. If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+        fun Something(): String {
+            ~~~~~~~~~
+        1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `passes when only one item emits up at the top level`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ItemKeyHashCodeDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ItemKeyHashCodeDetectorTest.kt
@@ -68,6 +68,41 @@ class ItemKeyHashCodeDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = listOf(ItemKeyHashCodeDetector.ISSUE)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.foundation.lazy.LazyColumn
+      import androidx.compose.foundation.lazy.items
+
+      data class Item(val id: String)
+
+      @Composable
+      fun Content(list: List<Item>) {
+        LazyColumn {
+          items(list, key = { it.hashCode() }) {}
+        }
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, lazyStub, pagerStub, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/Item.kt:10: Warning: Item keys in Lazy*/Pager/etc. layouts must be unique, but hashCode() is never guaranteed to be unique. Lazy* layouts throw at runtime when they encounter duplicate keys, so a hashCode-based key can crash as soon as data with a colliding hash comes along. Use a genuinely unique, stable identifier instead (e.g. a server-provided id).
+
+        See https://slackhq.github.io/compose-lints/rules/#dont-use-hashcode-as-a-key for more information. [ComposeItemKeyHashCode]
+            items(list, key = { it.hashCode() }) {}
+                                ~~~~~~~~~~~~~
+        0 errors, 1 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `errors when hashCode is used in a key`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/M2ApiDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/M2ApiDetectorTest.kt
@@ -56,7 +56,7 @@ class M2ApiDetectorTest : BaseComposeLintTest() {
     )
 
   @Test
-  fun smokeTest() {
+  fun testDocumentationExample() {
     lint()
       .configureOption(M2ApiDetector.ALLOW_LIST, "Surface")
       .files(

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierComposedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierComposedDetectorTest.kt
@@ -47,6 +47,47 @@ class ModifierComposedDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = listOf(ModifierComposedDetector.ISSUE)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+        package test
+
+      import androidx.compose.ui.composed
+      import androidx.compose.ui.Modifier
+
+      fun Modifier.something1() = Modifier.composed { }
+      fun Modifier.something2() = composed { }
+      fun Modifier.something3() = somethingElse()
+      """
+        .trimIndent()
+
+    lint()
+      .files(modifierStub, composed, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test/test.kt:6: Error: Modifier.composed { ... } is no longer recommended due to performance issues.
+
+        You should use the Modifier.Node API instead, as it was designed from the ground up to be far more performant than composed modifiers.
+
+        See https://slackhq.github.io/compose-lints/rules/#migrate-to-modifiernode for more information. [ComposeModifierComposed]
+        fun Modifier.something1() = Modifier.composed { }
+                                    ~~~~~~~~~~~~~~~~~~~~~
+        src/test/test.kt:7: Error: Modifier.composed { ... } is no longer recommended due to performance issues.
+
+        You should use the Modifier.Node API instead, as it was designed from the ground up to be far more performant than composed modifiers.
+
+        See https://slackhq.github.io/compose-lints/rules/#migrate-to-modifiernode for more information. [ComposeModifierComposed]
+        fun Modifier.something2() = composed { }
+                                    ~~~~~~~~~~~~
+        2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `errors when a composable Modifier extension is detected`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierMissingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierMissingDetectorTest.kt
@@ -15,6 +15,66 @@ class ModifierMissingDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = listOf(ModifierMissingDetector.ISSUE)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.ui.Modifier
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Something1() {
+          Row {
+          }
+      }
+      @Composable
+      fun Something2() {
+          Column(modifier = Modifier.fillMaxSize()) {
+          }
+      }
+      @Composable
+      fun Something3(): Unit {
+          SomethingElse {
+              Box(modifier = Modifier.fillMaxSize()) {
+              }
+          }
+      }
+      @Composable
+      fun Something4(modifier: Modifier = Modifier) {
+          Row {
+              Text("Hi!")
+          }
+      }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:5: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+        See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+        fun Something1() {
+            ~~~~~~~~~~
+        src/test.kt:10: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+        See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+        fun Something2() {
+            ~~~~~~~~~~
+        src/test.kt:15: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+        See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+        fun Something3(): Unit {
+            ~~~~~~~~~~
+        3 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `errors when a Composable has a layout inside and it doesn't have a modifier`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierReusedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierReusedDetectorTest.kt
@@ -24,6 +24,44 @@ class ModifierReusedDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+
+      @Composable
+      fun Something(modifier: Modifier) {
+          Row(modifier) {
+              OtherComposable(modifier)
+          }
+      }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, *specificStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:6: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth(). Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+        See https://slackhq.github.io/compose-lints/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+            Row(modifier) {
+                ~~~~~~~~
+        src/test.kt:7: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth(). Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+        See https://slackhq.github.io/compose-lints/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+                OtherComposable(modifier)
+                                ~~~~~~~~
+        2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `errors when the modifier parameter of a Composable is used more than once by siblings or parent-children`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ModifierWithoutDefaultDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ModifierWithoutDefaultDetectorTest.kt
@@ -15,6 +15,55 @@ class ModifierWithoutDefaultDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = listOf(ModifierWithoutDefaultDetector.ISSUE)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+
+      @Composable
+      fun Something(modifier: Modifier) { }
+      @Composable
+      fun Something(modifier: Modifier = Modifier, modifier2: Modifier) { }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:5: Error: This @Composable function has a modifier parameter but it doesn't have a default value.
+
+        See https://slackhq.github.io/compose-lints/rules/#modifiers-should-have-default-parameters for more information. [ComposeModifierWithoutDefault]
+        fun Something(modifier: Modifier) { }
+                      ~~~~~~~~~~~~~~~~~~
+        src/test.kt:7: Error: This @Composable function has a modifier parameter but it doesn't have a default value.
+
+        See https://slackhq.github.io/compose-lints/rules/#modifiers-should-have-default-parameters for more information. [ComposeModifierWithoutDefault]
+        fun Something(modifier: Modifier = Modifier, modifier2: Modifier) { }
+                                                     ~~~~~~~~~~~~~~~~~~~
+        2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/test.kt line 5: Add '= Modifier' default value.:
+        @@ -5 +5
+        - fun Something(modifier: Modifier) { }
+        + fun Something(modifier: Modifier = Modifier) { }
+        Autofix for src/test.kt line 7: Add '= Modifier' default value.:
+        @@ -7 +7
+        - fun Something(modifier: Modifier = Modifier, modifier2: Modifier) { }
+        + fun Something(modifier: Modifier = Modifier, modifier2: Modifier = Modifier) { }
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `errors when a Composable has modifiers but without default values`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MultipleContentEmittersDetectorTest.kt
@@ -21,6 +21,36 @@ class MultipleContentEmittersDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Something() {
+          Text("Hi")
+          Text("Hola")
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:3: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+        @Composable
+        ^
+        1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `passes when only one item emits up at the top level`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/MutableParametersDetectorTest.kt
@@ -20,6 +20,55 @@ class MutableParametersDetectorTest : BaseComposeLintTest() {
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.TYPE_ALIAS)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.MutableState
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Something(a: MutableState<String>) {}
+      @Composable
+      fun Something(a: ArrayList<String>) {}
+      @Composable
+      fun Something(a: HashSet<String>) {}
+      @Composable
+      fun Something(a: MutableMap<String, String>) {}
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:5: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app. Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
+        fun Something(a: MutableState<String>) {}
+                         ~~~~~~~~~~~~~~~~~~~~
+        src/test.kt:7: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app. Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
+        fun Something(a: ArrayList<String>) {}
+                         ~~~~~~~~~~~~~~~~~
+        src/test.kt:9: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app. Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
+        fun Something(a: HashSet<String>) {}
+                         ~~~~~~~~~~~~~~~
+        src/test.kt:11: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app. Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-use-inherently-mutable-types-as-parameters for more information. [ComposeMutableParameters]
+        fun Something(a: MutableMap<String, String>) {}
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        4 errors
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `mutable parameters are reported by default`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ParameterOrderDetectorTest.kt
@@ -15,6 +15,55 @@ class ParameterOrderDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = listOf(ParameterOrderDetector.ISSUE)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+
+      @Composable
+      fun MyComposable(modifier: Modifier = Modifier, other: String, other2: String) { }
+
+      @Composable
+      fun MyComposable(text: String = "deffo", modifier: Modifier = Modifier) { }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:5: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+        Current params are: [modifier: Modifier = Modifier, other: String, other2: String] but should be [other: String, other2: String, modifier: Modifier = Modifier].
+        See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
+        fun MyComposable(modifier: Modifier = Modifier, other: String, other2: String) { }
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test.kt:8: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+        Current params are: [text: String = "deffo", modifier: Modifier = Modifier] but should be [modifier: Modifier = Modifier, text: String = "deffo"].
+        See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information. [ComposeParameterOrder]
+        fun MyComposable(text: String = "deffo", modifier: Modifier = Modifier) { }
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        2 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Fix for src/test.kt line 5: Replace with (other: String, other2: String, modifier: Modifier = Modifier):
+        @@ -5 +5
+        - fun MyComposable(modifier: Modifier = Modifier, other: String, other2: String) { }
+        + fun MyComposable(other: String, other2: String, modifier: Modifier = Modifier) { }
+        Fix for src/test.kt line 8: Replace with (modifier: Modifier = Modifier, text: String = "deffo"):
+        @@ -8 +8
+        - fun MyComposable(text: String = "deffo", modifier: Modifier = Modifier) { }
+        + fun MyComposable(modifier: Modifier = Modifier, text: String = "deffo") { }
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `no errors when ordering is correct`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/PreviewNamingDetectorTest.kt
@@ -15,6 +15,44 @@ class PreviewNamingDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = listOf(PreviewNamingDetector.ISSUE)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.ui.tooling.preview.Preview
+
+      @Preview
+      annotation class Banana
+      @Preview
+      annotation class BananaPreviews
+      @BananaPreviews
+      annotation class WithBananaPreviews
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/Banana.kt:3: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
+        See https://slackhq.github.io/compose-lints/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
+        @Preview
+        ^
+        src/Banana.kt:5: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
+        See https://slackhq.github.io/compose-lints/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
+        @Preview
+        ^
+        src/Banana.kt:7: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
+        See https://slackhq.github.io/compose-lints/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
+        @BananaPreviews
+        ^
+        3 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `passes for non-preview annotations`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/RedundantComposableDetectorTest.kt
@@ -125,6 +125,66 @@ class RedundantComposableDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = RedundantComposableDetector.ISSUES.toList()
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun redundant() = println("derp")
+
+      @Composable
+      fun stillRedundant(name: String) {
+        println(name.length)
+      }
+
+      val redundantProperty: Int
+        @Composable get() = 3
+      """
+        .trimIndent()
+    lint()
+      .files(stubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:3: Warning: This declaration is annotated with @Composable but doesn't call any other @Composable functions or read any @Composable properties (like a CompositionLocal's current), so it doesn't use the composition and the @Composable annotation can be removed.
+
+        See https://slackhq.github.io/compose-lints/rules/#remove-unnecessary-composable-annotations for more information. [ComposeRedundantComposable]
+        @Composable
+        ~~~~~~~~~~~
+        src/test.kt:6: Warning: This declaration is annotated with @Composable but doesn't call any other @Composable functions or read any @Composable properties (like a CompositionLocal's current), so it doesn't use the composition and the @Composable annotation can be removed.
+
+        See https://slackhq.github.io/compose-lints/rules/#remove-unnecessary-composable-annotations for more information. [ComposeRedundantComposable]
+        @Composable
+        ~~~~~~~~~~~
+        src/test.kt:12: Warning: This declaration is annotated with @Composable but doesn't call any other @Composable functions or read any @Composable properties (like a CompositionLocal's current), so it doesn't use the composition and the @Composable annotation can be removed.
+
+        See https://slackhq.github.io/compose-lints/rules/#remove-unnecessary-composable-annotations for more information. [ComposeRedundantComposable]
+          @Composable get() = 3
+          ~~~~~~~~~~~
+        0 errors, 3 warnings
+        """
+          .trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/test.kt line 3: Remove redundant @Composable:
+        @@ -3 +2,0 @@
+        -@Composable
+        Autofix for src/test.kt line 6: Remove redundant @Composable:
+        @@ -6 +5,0 @@
+        -@Composable
+        Autofix for src/test.kt line 12: Remove redundant @Composable:
+        @@ -12 +12 @@
+        -  @Composable get() = 3
+        +  get() = 3
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `errors when a composable does not use composition`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/SlotReusedDetectorTest.kt
@@ -14,6 +14,43 @@ class SlotReusedDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = listOf(SlotReusedDetector.ISSUE)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+
+      @Composable
+      fun Something(
+        modifier: Modifier = Modifier,
+        slot: @Composable () -> Unit,
+      ) {
+        Row(modifier) {
+          slot()
+          slot()
+        }
+      }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:7: Error: Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot's internal state when the invoking location changes.
+
+        See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information. [SlotReused]
+          slot: @Composable () -> Unit,
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `errors when the slot parameter of a Composable is used more than once at the same time`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableCollectionsDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableCollectionsDetectorTest.kt
@@ -37,6 +37,55 @@ class UnstableCollectionsDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun Something(a: Collection<String>) {}
+      @Composable
+      fun Something(a: List<String>) {}
+      @Composable
+      fun Something(a: Set<String>) {}
+      @Composable
+      fun Something(a: Map<String, Int>) {}
+      """
+        .trimIndent()
+
+    lint()
+      .files(enabledIssueConfig, *commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/test.kt:4: Warning: The Compose Compiler cannot infer the stability of a parameter if a Collection<String> is used in it, even if the item type is stable.
+        You should use Kotlinx Immutable Collections instead: a: ImmutableCollection<String> or create an @Immutable wrapper for this class: @Immutable data class ACollection(val items: Collection<String>)
+        See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information. [ComposeUnstableCollections]
+        fun Something(a: Collection<String>) {}
+                         ~~~~~~~~~~~~~~~~~~
+        src/test.kt:6: Warning: The Compose Compiler cannot infer the stability of a parameter if a List<String> is used in it, even if the item type is stable.
+        You should use Kotlinx Immutable Collections instead: a: ImmutableList<String> or create an @Immutable wrapper for this class: @Immutable data class AList(val items: List<String>)
+        See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information. [ComposeUnstableCollections]
+        fun Something(a: List<String>) {}
+                         ~~~~~~~~~~~~
+        src/test.kt:8: Warning: The Compose Compiler cannot infer the stability of a parameter if a Set<String> is used in it, even if the item type is stable.
+        You should use Kotlinx Immutable Collections instead: a: ImmutableSet<String> or create an @Immutable wrapper for this class: @Immutable data class ASet(val items: Set<String>)
+        See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information. [ComposeUnstableCollections]
+        fun Something(a: Set<String>) {}
+                         ~~~~~~~~~~~
+        src/test.kt:10: Warning: The Compose Compiler cannot infer the stability of a parameter if a Map<String, Int> is used in it, even if the item type is stable.
+        You should use Kotlinx Immutable Collections instead: a: ImmutableMap<String, Int> or create an @Immutable wrapper for this class: @Immutable data class AMap(val items: Map<String, Int>)
+        See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information. [ComposeUnstableCollections]
+        fun Something(a: Map<String, Int>) {}
+                         ~~~~~~~~~~~~~~~~
+        0 errors, 4 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `warnings when a Composable has a Collection List Set Map parameter`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/UnstableReceiverDetectorTest.kt
@@ -30,6 +30,51 @@ class UnstableReceiverDetectorTest : BaseComposeLintTest() {
   }
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      interface ExampleInterface {
+        @Composable fun Content()
+      }
+
+      class Example {
+        @Composable fun Content() {}
+      }
+
+      @Composable
+      fun Example.OtherContent() {}
+      """
+        .trimIndent()
+    lint()
+      .files(enabledIssueConfig, *commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/ExampleInterface.kt:4: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible.
+
+        See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+          @Composable fun Content()
+                          ~~~~~~~
+        src/ExampleInterface.kt:8: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible.
+
+        See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+          @Composable fun Content() {}
+                          ~~~~~~~
+        src/ExampleInterface.kt:12: Warning: Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn't possible.
+
+        See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information. [ComposeUnstableReceiver]
+        fun Example.OtherContent() {}
+            ~~~~~~~
+        0 errors, 3 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `stable receiver types report no errors`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ViewModelForwardingDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ViewModelForwardingDetectorTest.kt
@@ -15,6 +15,37 @@ class ViewModelForwardingDetectorTest : BaseComposeLintTest() {
   override fun getIssues(): List<Issue> = listOf(ViewModelForwardingDetector.ISSUE)
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+      import androidx.compose.runtime.Composable
+
+      class MyViewModel
+
+      @Composable
+      fun MyComposable(viewModel: MyViewModel) {
+          AnotherComposable(viewModel)
+      }
+      """
+        .trimIndent()
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+        src/MyViewModel.kt:7: Error: Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using state hoisting.
+
+        See https://slackhq.github.io/compose-lints/rules/#hoist-all-the-things for more information. [ComposeViewModelForwarding]
+            AnotherComposable(viewModel)
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `allows the forwarding of ViewModels in overridden Composable functions`() {
     @Language("kotlin")
     val code =

--- a/compose-lint-checks/src/test/java/slack/lint/compose/ViewModelInjectionDetectorTest.kt
+++ b/compose-lint-checks/src/test/java/slack/lint/compose/ViewModelInjectionDetectorTest.kt
@@ -39,6 +39,37 @@ class ViewModelInjectionDetectorTest(private val viewModel: String) : BaseCompos
   }
 
   @Test
+  fun testDocumentationExample() {
+    @Language("kotlin")
+    val code =
+      """
+       import androidx.compose.runtime.Composable
+       import androidx.compose.ui.Modifier
+
+        @Composable
+       fun MyComposable(modifier: Modifier) {
+         val myViewModel = viewModel<MyVM>()
+       }
+      """
+        .trimIndent()
+
+    lint()
+      .files(*commonStubs, kotlin(code))
+      .run()
+      .expect(
+        """
+            src/test.kt:6: Error: Implicit dependencies of composables should be made explicit.
+            Usages of viewModel to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
+            See https://slackhq.github.io/compose-lints/rules/#viewmodels for more information. [ComposeViewModelInjection]
+              val myViewModel = viewModel<MyVM>()
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `passes when a weaverViewModel is used as a default param`() {
     @Language("kotlin")
     val code =


### PR DESCRIPTION
## Summary

Closes #252.

Adds a `testDocumentationExample` method to every detector test class that was missing one, giving each lint rule a canonical test that mirrors the primary violation example shown in the documentation.

- **M2ApiDetectorTest** — renamed existing `smokeTest` → `testDocumentationExample` (as suggested in the issue)
- **17 other test classes** — added a new focused `testDocumentationExample` covering the core violation for each rule:
  - `CompositionLocalUsageDetectorTest` — `staticCompositionLocalOf` / `compositionLocalOf` definitions
  - `ContentEmitterReturningValuesDetectorTest` — composable that emits content AND returns a value
  - `ItemKeyHashCodeDetectorTest` — `hashCode()` used as a `LazyColumn` item key
  - `ModifierComposedDetectorTest` — `Modifier.composed { }` usage
  - `ModifierMissingDetectorTest` — composable with layout but no `modifier` parameter
  - `ModifierReusedDetectorTest` — modifier passed to both root and child composable
  - `ModifierWithoutDefaultDetectorTest` — `modifier: Modifier` param without `= Modifier` default
  - `MultipleContentEmittersDetectorTest` — composable calling `Text()` twice at top level
  - `MutableParametersDetectorTest` — `MutableState`, `ArrayList`, `HashSet`, `MutableMap` params
  - `ParameterOrderDetectorTest` — modifier before required params / default param before modifier
  - `PreviewNamingDetectorTest` — `@Preview` annotation class not ending in `Preview`
  - `RedundantComposableDetectorTest` — `@Composable` on a function that never calls composables
  - `SlotReusedDetectorTest` — slot lambda invoked twice in the same composable
  - `UnstableCollectionsDetectorTest` — `List`, `Set`, `Map`, `Collection` as composable params
  - `UnstableReceiverDetectorTest` — `@Composable` members on unstable interface/class
  - `ViewModelForwardingDetectorTest` — ViewModel passed as argument to another composable
  - `ViewModelInjectionDetectorTest` — `viewModel<MyVM>()` called inside a composable body

## Test plan

- [x] All 18 new/renamed `testDocumentationExample` tests pass
- [x] Full test suite passes with no regressions (`./gradlew :compose-lint-checks:test`)
