### PR TITLE
fix: reclassify `ComposeModifierComposed` as a `PERFORMANCE` issue

### DIFF
--- a/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposedDetector.kt
+++ b/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposedDetector.kt
@@ -22,16 +22,16 @@ class ModifierComposedDetector : Detector(), SourceCodeScanner {
     val ISSUE =
       Issue.create(
         id = "ComposeModifierComposed",
-        briefDescription = "Don't use Modifier.composed {}",
+        briefDescription = "Don't use `Modifier.composed {}`",
         explanation =
           """
-          Modifier.composed { ... } is no longer recommended due to performance issues.
+          `Modifier.composed { ... }` is no longer recommended due to performance issues.
 
-          You should use the Modifier.Node API instead, as it was designed from the ground up to be far more performant than composed modifiers.
+          You should use the `Modifier.Node` API instead, as it was designed from the ground up to be far more performant than composed modifiers.
 
           See https://slackhq.github.io/compose-lints/rules/#migrate-to-modifiernode for more information.
         """,
-        category = Category.CORRECTNESS,
+        category = Category.PERFORMANCE,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,
         implementation = sourceImplementation<ModifierComposedDetector>(),


### PR DESCRIPTION
and update the messages to use backticks for code references

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.

Please read our [Contributing Guidelines](https://github.com/slackhq/compose-lints/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->