### PR TITLE
docs: remove obsolete ComposeComposableModifier guidance

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -424,16 +424,6 @@ More info: [Modifier documentation](https://developer.android.com/reference/kotl
 
 Related rule: [`ComposeModifierWithoutDefault`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ModifierWithoutDefaultDetector.kt)
 
-### Avoid Modifier extension factory functions
-
-Using `@Composable` builder functions for modifiers is not recommended, as they cause unnecessary recompositions. To avoid this, you should use `Modifier.Node` instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
-
-Composed modifiers may be created outside of composition, shared across elements, and declared as top-level constants, making them more flexible than modifiers that can only be created via a `@Composable` function call, and easier to avoid accidentally sharing state across elements.
-
-More info: [Modifier extensions](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#extension-functions), [Composed modifiers in Jetpack Compose by Jorge Castillo](https://jorgecastillo.dev/composed-modifiers-in-jetpack-compose) and [Custom Modifiers](https://developer.android.com/jetpack/compose/custom-modifiers)
-
-Related rule: [`ComposeComposableModifier`](https://github.com/slackhq/compose-lints/blob/main/compose-lint-checks/src/main/java/slack/lint/compose/ModifierComposableDetector.kt)
-
 ### Migrate to `Modifier.Node`
 
 `Modifier.composed { ... }` is no longer recommended due to performance issues.


### PR DESCRIPTION
## Summary

- remove the obsolete `ComposeComposableModifier` guidance from the rules page
- keep the separate, current `ComposeModifierComposed` / `Modifier.Node` guidance unchanged

## Why

The detector and rule were removed in #378 and the 1.4.0 changelog records that removal, but the documentation still links to the deleted detector source. The stale source link now returns 404.

## Validation

- `gradlew.bat test` (Temurin 26.0.2+1)
- patched `mkdocs build` with the repository-pinned Python requirements
- `git diff --check`
